### PR TITLE
Guard against potential NPEs resulting from no-writer topology

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/TopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/TopologyService.java
@@ -101,13 +101,13 @@ public interface TopologyService {
   void setLastUsedReaderHost(HostInfo reader);
 
   /**
-   * Return an index of the host associated with a provided connection in topology host list.
+   * Return the {@link HostInfo} object that is associated with a provided connection from the topology host list.
    *
    * @param conn A connection to database.
-   * @return A index in topology host list. Returns -1 (NO_CONNECTION_INDEX), if connection host is
+   * @return The HostInfo object from the topology host list. Returns null if the connection host is
    *     not found in the latest topology.
    */
-  int getHostIndexByName(JdbcConnection conn);
+  HostInfo getHostByName(JdbcConnection conn);
 
   /**
    * Get a set of instance names that were marked down.
@@ -117,20 +117,18 @@ public interface TopologyService {
   Set<String> getDownHosts();
 
   /**
-   * Mark host down. Host stays marked down till next topology refresh.
+   * Mark host as down. Host stays marked down until next topology refresh.
    *
-   * @param currentHostPortPair A host dns endpoint and port to mark down. For example:
-   *     "instance-1.my-domain.com:3306".
+   * @param downHost The {@link HostInfo} object representing the host to mark as down
    */
-  void addDownHost(String currentHostPortPair);
+  void addToDownHostList(HostInfo downHost);
 
   /**
-   * Unmark host down.
+   * Unmark host as down. The host is removed from the list of down hosts
    *
-   * @param currentHostPortPair A host dns endpoint and port to unmark down. For example:
-   *     "instance-1.my-domain.com:3306".
+   * @param host The {@link HostInfo} object representing the host to remove from the list of down hosts
    */
-  void removeDownHost(String currentHostPortPair);
+  void removeFromDownHostList(HostInfo host);
 
   /**
    * Check if topology belongs to multi-writer cluster.

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/AuroraTopologyServiceTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/AuroraTopologyServiceTest.java
@@ -350,14 +350,14 @@ public class AuroraTopologyServiceTest {
   }
 
   @Test
-  public void testGetHostIndexByName_success() throws SQLException {
+  public void testGetHostByName_success() throws SQLException {
     final JdbcConnection mockConn = Mockito.mock(ConnectionImpl.class);
     final Statement mockStatement = Mockito.mock(StatementImpl.class);
     final ResultSet mockResultSet = Mockito.mock(ResultSetImpl.class);
     stubTopologyQuery(mockConn, mockStatement, mockResultSet);
 
     // populate cache
-    spyProvider.getTopology(mockConn, false);
+    List<HostInfo> topology = spyProvider.getTopology(mockConn, false);
 
     final String connectionHostName = "replica-instance-2";
     final int connectionHostIndex = 2;
@@ -369,12 +369,12 @@ public class AuroraTopologyServiceTest {
     when(mockResultSet.getString(AuroraTopologyService.GET_INSTANCE_NAME_COL))
         .thenReturn(connectionHostName);
 
-    final int hostIndex = spyProvider.getHostIndexByName(mockConn);
-    assertEquals(connectionHostIndex, hostIndex);
+    final HostInfo host = spyProvider.getHostByName(mockConn);
+    assertEquals(topology.get(connectionHostIndex), host);
   }
 
   @Test
-  public void testGetHostIndexByName_noServerId() throws SQLException {
+  public void testGetHostByName_noServerId() throws SQLException {
     final JdbcConnection mockConn = Mockito.mock(ConnectionImpl.class);
     final Statement mockStatement = Mockito.mock(StatementImpl.class);
     final ResultSet mockResultSet = Mockito.mock(ResultSetImpl.class);
@@ -383,12 +383,12 @@ public class AuroraTopologyServiceTest {
         .thenReturn(mockResultSet);
     when(mockResultSet.next()).thenReturn(false);
 
-    final int hostIndex = spyProvider.getHostIndexByName(mockConn);
-    assertEquals(AuroraTopologyService.NO_CONNECTION_INDEX, hostIndex);
+    final HostInfo host = spyProvider.getHostByName(mockConn);
+    assertNull(host);
   }
 
   @Test
-  public void testGetHostIndexByName_exception() throws SQLException {
+  public void testGetHostByName_exception() throws SQLException {
     final JdbcConnection mockConn = Mockito.mock(ConnectionImpl.class);
     final Statement mockStatement = Mockito.mock(StatementImpl.class);
     final ResultSet mockResultSet = Mockito.mock(ResultSetImpl.class);
@@ -397,8 +397,8 @@ public class AuroraTopologyServiceTest {
         .thenReturn(mockResultSet);
     when(mockResultSet.next()).thenThrow(SQLException.class);
 
-    final int hostIndex = spyProvider.getHostIndexByName(mockConn);
-    assertEquals(AuroraTopologyService.NO_CONNECTION_INDEX, hostIndex);
+    final HostInfo host = spyProvider.getHostByName(mockConn);
+    assertNull(host);
   }
 
   @Test
@@ -538,7 +538,7 @@ public class AuroraTopologyServiceTest {
     spyProvider.setClusterInstanceHost(clusterInstanceInfo);
 
     spyProvider.getTopology(mockConn, false);
-    spyProvider.addDownHost(clusterInstanceInfo.getHostPortPair());
+    spyProvider.addToDownHostList(clusterInstanceInfo);
     assertEquals(1, AuroraTopologyService.topologyCache.size());
 
     spyProvider.clearAll();

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxyTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxyTest.java
@@ -629,7 +629,6 @@ public class ClusterAwareConnectionProxyTest {
         "jdbc:mysql://my-cluster-name.cluster-czygpppufgy4.us-east-2.rds.amazonaws.com:1234/test";
     final ConnectionUrl conStr = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
     final TopologyService mockTopologyService = Mockito.mock(TopologyService.class);
-    final int connectionHostIndex = ClusterAwareConnectionProxy.WRITER_CONNECTION_INDEX;
 
     final HostInfo writerHost = createBasicHostInfo("writer-host");
     final HostInfo readerA_Host = createBasicHostInfo("reader-a-host");
@@ -641,7 +640,7 @@ public class ClusterAwareConnectionProxyTest {
 
     when(mockTopologyService.getCachedTopology()).thenReturn(topology);
     when(mockTopologyService.getTopology(eq(mockConn), any(Boolean.class))).thenReturn(topology);
-    when(mockTopologyService.getHostIndexByName(mockConn)).thenReturn(connectionHostIndex);
+    when(mockTopologyService.getHostByName(mockConn)).thenReturn(writerHost);
     when(mockConnectionProvider.connect(writerHost)).thenReturn(mockConn);
 
     final ClusterAwareConnectionProxy proxy =
@@ -685,7 +684,7 @@ public class ClusterAwareConnectionProxyTest {
 
     when(mockTopologyService.getTopology(eq(mockConn), any(Boolean.class))).thenReturn(topology);
     when(mockTopologyService.getCachedTopology()).thenReturn(topology);
-    when(mockTopologyService.getHostIndexByName(mockConn)).thenReturn(connectionHostIndex);
+    when(mockTopologyService.getHostByName(mockConn)).thenReturn(readerAHost);
 
     final ClusterAwareConnectionProxy proxy =
         new ClusterAwareConnectionProxy(
@@ -726,7 +725,7 @@ public class ClusterAwareConnectionProxyTest {
     when(mockTopologyService.getCachedTopology()).thenReturn(topology);
     when(mockTopologyService.getLastUsedReaderHost()).thenReturn(readerA_Host);
     when(mockTopologyService.getTopology(eq(mockConn), any(Boolean.class))).thenReturn(topology);
-    when(mockTopologyService.getHostIndexByName(mockConn)).thenReturn(newConnectionHostIndex);
+    when(mockTopologyService.getHostByName(mockConn)).thenReturn(readerB_Host);
 
     final ClusterAwareConnectionProxy proxy =
         new ClusterAwareConnectionProxy(
@@ -774,7 +773,7 @@ public class ClusterAwareConnectionProxyTest {
     when(mockTopologyService.getCachedTopology()).thenReturn(cachedTopology);
     when(mockTopologyService.getTopology(eq(mockCachedWriterConn), any(Boolean.class)))
         .thenReturn(actualTopology);
-    when(mockTopologyService.getHostIndexByName(mockCachedWriterConn)).thenReturn(2);
+    when(mockTopologyService.getHostByName(mockCachedWriterConn)).thenReturn(obsoleteWriterHost);
 
     ConnectionProvider mockConnectionProvider = Mockito.mock(ConnectionProvider.class);
     when(mockConnectionProvider.connect(cachedWriterHost)).thenReturn(mockCachedWriterConn);
@@ -823,8 +822,8 @@ public class ClusterAwareConnectionProxyTest {
 
     when(mockTopologyService.getTopology(eq(mockDirectReaderConn), any(Boolean.class)))
         .thenReturn(topology);
-    when(mockTopologyService.getHostIndexByName(mockDirectReaderConn))
-        .thenReturn(ClusterAwareConnectionProxy.NO_CONNECTION_INDEX);
+    when(mockTopologyService.getHostByName(mockDirectReaderConn))
+        .thenReturn(null);
 
     final ConnectionProvider mockConnectionProvider = Mockito.mock(ConnectionProvider.class);
     when(mockConnectionProvider.connect(conStr.getMainHost())).thenReturn(mockDirectReaderConn);
@@ -855,7 +854,6 @@ public class ClusterAwareConnectionProxyTest {
         "jdbc:mysql://my-cluster-name.cluster-ro-czygpppufgy4.us-east-2.rds.amazonaws.com:1234/test";
     final ConnectionUrl conStr = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
     final TopologyService mockTopologyService = Mockito.mock(TopologyService.class);
-    final int initialHostIndex = 2;
 
     final HostInfo writerHost = createBasicHostInfo("writer-host");
     final HostInfo readerA_Host = createBasicHostInfo("reader-a-host");
@@ -867,7 +865,7 @@ public class ClusterAwareConnectionProxyTest {
 
     when(mockTopologyService.getTopology(eq(mockReaderConnection), any(Boolean.class)))
         .thenReturn(topology);
-    when(mockTopologyService.getHostIndexByName(mockReaderConnection)).thenReturn(initialHostIndex);
+    when(mockTopologyService.getHostByName(mockReaderConnection)).thenReturn(readerB_Host);
 
     final ConnectionProvider mockConnectionProvider = Mockito.mock(ConnectionProvider.class);
     when(mockConnectionProvider.connect(conStr.getMainHost())).thenReturn(mockReaderConnection);

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareReaderFailoverHandlerTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareReaderFailoverHandlerTest.java
@@ -110,9 +110,9 @@ public class ClusterAwareReaderFailoverHandlerTest {
     assertEquals(successHostIndex, result.getConnectionIndex());
 
     final HostInfo successHost = hosts.get(successHostIndex);
-    verify(mockTopologyService, atLeast(4)).addDownHost(any());
-    verify(mockTopologyService, never()).addDownHost(eq(successHost.getHostPortPair()));
-    verify(mockTopologyService, times(1)).removeDownHost(eq(successHost.getHostPortPair()));
+    verify(mockTopologyService, atLeast(4)).addToDownHostList(any());
+    verify(mockTopologyService, never()).addToDownHostList(eq(successHost));
+    verify(mockTopologyService, times(1)).removeFromDownHostList(eq(successHost));
   }
 
   private List<HostInfo> getHostsFromTestUrls(int numHosts) {
@@ -142,7 +142,7 @@ public class ClusterAwareReaderFailoverHandlerTest {
     assertFalse(result.isSuccess());
     assertNull(result.getConnection());
     assertEquals(ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, result.getConnectionIndex());
-    verify(mockTopologyService, times(1)).addDownHost(eq(currentHost.getHostPortPair()));
+    verify(mockTopologyService, times(1)).addToDownHostList(eq(currentHost));
 
     final List<HostInfo> hosts = new ArrayList<>();
     result = target.failover(hosts, currentHost);
@@ -150,7 +150,7 @@ public class ClusterAwareReaderFailoverHandlerTest {
     assertNull(result.getConnection());
     assertEquals(ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, result.getConnectionIndex());
 
-    verify(mockTopologyService, times(2)).addDownHost(eq(currentHost.getHostPortPair()));
+    verify(mockTopologyService, times(2)).addToDownHostList(eq(currentHost));
   }
 
   @Test
@@ -182,8 +182,8 @@ public class ClusterAwareReaderFailoverHandlerTest {
     assertSame(mockConnection, result.getConnection());
     assertEquals(2, result.getConnectionIndex());
 
-    verify(mockTopologyService, never()).addDownHost(any());
-    verify(mockTopologyService, times(1)).removeDownHost(eq(fastHost.getHostPortPair()));
+    verify(mockTopologyService, never()).addToDownHostList(any());
+    verify(mockTopologyService, times(1)).removeFromDownHostList(eq(fastHost));
   }
 
   @Test
@@ -208,10 +208,10 @@ public class ClusterAwareReaderFailoverHandlerTest {
     assertEquals(ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, result.getConnectionIndex());
 
     final HostInfo currentHost = hosts.get(currentHostIndex);
-    verify(mockTopologyService, atLeastOnce()).addDownHost(eq(currentHost.getHostPortPair()));
+    verify(mockTopologyService, atLeastOnce()).addToDownHostList(eq(currentHost));
     verify(mockTopologyService, never())
-        .addDownHost(
-            eq(hosts.get(ClusterAwareConnectionProxy.WRITER_CONNECTION_INDEX).getHostPortPair()));
+        .addToDownHostList(
+            eq(hosts.get(ClusterAwareConnectionProxy.WRITER_CONNECTION_INDEX)));
   }
 
   @Test
@@ -244,7 +244,7 @@ public class ClusterAwareReaderFailoverHandlerTest {
     assertNull(result.getConnection());
     assertEquals(ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, result.getConnectionIndex());
 
-    verify(mockTopologyService, never()).addDownHost(any());
+    verify(mockTopologyService, never()).addToDownHostList(any());
   }
 
   @Test

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareWriterFailoverHandlerTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareWriterFailoverHandlerTest.java
@@ -113,8 +113,8 @@ public class ClusterAwareWriterFailoverHandlerTest {
     assertSame(result.getNewConnection(), mockConnection);
 
     final InOrder inOrder = Mockito.inOrder(mockTopologyService);
-    inOrder.verify(mockTopologyService).addDownHost(eq(writerHost.getHostPortPair()));
-    inOrder.verify(mockTopologyService).removeDownHost(eq(writerHost.getHostPortPair()));
+    inOrder.verify(mockTopologyService).addToDownHostList(eq(writerHost));
+    inOrder.verify(mockTopologyService).removeFromDownHostList(eq(writerHost));
   }
 
   private HostInfo createBasicHostInfo(String instanceName) {
@@ -185,8 +185,8 @@ public class ClusterAwareWriterFailoverHandlerTest {
     assertSame(result.getNewConnection(), mockWriterConnection);
 
     final InOrder inOrder = Mockito.inOrder(mockTopologyService);
-    inOrder.verify(mockTopologyService).addDownHost(eq(writerHost.getHostPortPair()));
-    inOrder.verify(mockTopologyService).removeDownHost(eq(writerHost.getHostPortPair()));
+    inOrder.verify(mockTopologyService).addToDownHostList(eq(writerHost));
+    inOrder.verify(mockTopologyService).removeFromDownHostList(eq(writerHost));
   }
 
   /**
@@ -243,8 +243,8 @@ public class ClusterAwareWriterFailoverHandlerTest {
     assertSame(result.getNewConnection(), mockWriterConnection);
 
     final InOrder inOrder = Mockito.inOrder(mockTopologyService);
-    inOrder.verify(mockTopologyService).addDownHost(eq(writerHost.getHostPortPair()));
-    inOrder.verify(mockTopologyService).removeDownHost(eq(writerHost.getHostPortPair()));
+    inOrder.verify(mockTopologyService).addToDownHostList(eq(writerHost));
+    inOrder.verify(mockTopologyService).removeFromDownHostList(eq(writerHost));
   }
 
   /**
@@ -315,8 +315,8 @@ public class ClusterAwareWriterFailoverHandlerTest {
     assertEquals(3, result.getTopology().size());
     assertEquals("new-writer-host", result.getTopology().get(0).getHost());
 
-    verify(mockTopologyService, times(1)).addDownHost(eq(writerHost.getHostPortPair()));
-    verify(mockTopologyService, times(1)).removeDownHost(eq(newWriterHost.getHostPortPair()));
+    verify(mockTopologyService, times(1)).addToDownHostList(eq(writerHost));
+    verify(mockTopologyService, times(1)).removeFromDownHostList(eq(newWriterHost));
   }
 
   /**
@@ -385,8 +385,8 @@ public class ClusterAwareWriterFailoverHandlerTest {
     assertEquals(4, result.getTopology().size());
     assertEquals("new-writer-host", result.getTopology().get(0).getHost());
 
-    verify(mockTopologyService, times(1)).addDownHost(eq(initialWriterHost.getHostPortPair()));
-    verify(mockTopologyService, times(1)).removeDownHost(eq(newWriterHost.getHostPortPair()));
+    verify(mockTopologyService, times(1)).addToDownHostList(eq(initialWriterHost));
+    verify(mockTopologyService, times(1)).removeFromDownHostList(eq(newWriterHost));
   }
 
   /**
@@ -460,7 +460,7 @@ public class ClusterAwareWriterFailoverHandlerTest {
     assertFalse(result.isConnected());
     assertFalse(result.isNewHost());
 
-    verify(mockTopologyService, times(1)).addDownHost(eq(writerHost.getHostPortPair()));
+    verify(mockTopologyService, times(1)).addToDownHostList(eq(writerHost));
   }
 
   /**
@@ -517,7 +517,7 @@ public class ClusterAwareWriterFailoverHandlerTest {
     assertFalse(result.isConnected());
     assertFalse(result.isNewHost());
 
-    verify(mockTopologyService, times(1)).addDownHost(eq(writerHost.getHostPortPair()));
-    verify(mockTopologyService, atLeastOnce()).addDownHost(eq(newWriterHost.getHostPortPair()));
+    verify(mockTopologyService, times(1)).addToDownHostList(eq(writerHost));
+    verify(mockTopologyService, atLeastOnce()).addToDownHostList(eq(newWriterHost));
   }
 }


### PR DESCRIPTION
*Description of changes:*
- Implemented guards against potential NPEs that could result from a no-writer topology
- cleaned up the ClusterAwareConnectionProxy class