### PR TITLE
Throw connection error specific exception during long running query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 .idea
 hs_err_pid*.log
 *.sh
+update_session_token.py

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -162,7 +162,7 @@ dependencies {
     testImplementation("org.junit.platform:junit-platform-commons:1.6.2")
     testImplementation("org.junit.platform:junit-platform-engine:1.6.2")
     testImplementation("org.junit.platform:junit-platform-launcher:1.6.2")
-    testImplementation("org.mockito:mockito-core:3.6.0")
+    testImplementation("org.mockito:mockito-inline:3.6.28")
     implementation("org.apiguardian:apiguardian-api:1.1.0")
     implementation("org.opentest4j:opentest4j:1.2.0")
     implementation("org.javassist:javassist:3.27.0-GA")

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeProtocolProvider.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeProtocolProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Modifications Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2.0, as published by the
+ * Free Software Foundation.
+ *
+ * This program is also distributed with certain software (including but not
+ * limited to OpenSSL) that is licensed under separate terms, as designated in a
+ * particular file or component or in included license documentation. The
+ * authors of MySQL hereby grant you an additional permission to link the
+ * program and your derivative works with the separately licensed software that
+ * they have included with MySQL.
+ *
+ * Without limiting anything contained in the foregoing, this file, which is
+ * part of MySQL Connector/J, is also subject to the Universal FOSS Exception,
+ * version 1.0, a copy of which can be found at
+ * http://oss.oracle.com/licenses/universal-foss-exception.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License, version 2.0,
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+package com.mysql.cj.protocol.a;
+
+import com.mysql.cj.Session;
+import com.mysql.cj.TransactionEventHandler;
+import com.mysql.cj.conf.PropertySet;
+import com.mysql.cj.log.Log;
+import com.mysql.cj.protocol.SocketConnection;
+
+public class NativeProtocolProvider implements ProtocolProvider {
+
+    @Override
+    public NativeProtocol getProtocolInstance(Session session, SocketConnection socketConnection, PropertySet propertySet, Log log, TransactionEventHandler transactionManager) {
+        return NativeProtocol.getInstance(session, socketConnection, propertySet, log, transactionManager);
+    }
+}

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeSocketConnectionProvider.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeSocketConnectionProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Modifications Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2.0, as published by the
+ * Free Software Foundation.
+ *
+ * This program is also distributed with certain software (including but not
+ * limited to OpenSSL) that is licensed under separate terms, as designated in a
+ * particular file or component or in included license documentation. The
+ * authors of MySQL hereby grant you an additional permission to link the
+ * program and your derivative works with the separately licensed software that
+ * they have included with MySQL.
+ *
+ * Without limiting anything contained in the foregoing, this file, which is
+ * part of MySQL Connector/J, is also subject to the Universal FOSS Exception,
+ * version 1.0, a copy of which can be found at
+ * http://oss.oracle.com/licenses/universal-foss-exception.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License, version 2.0,
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+package com.mysql.cj.protocol.a;
+
+import com.mysql.cj.protocol.SocketConnection;
+
+public class NativeSocketConnectionProvider implements SocketConnectionProvider {
+    @Override
+    public SocketConnection getSocketConnection() {
+        return new NativeSocketConnection();
+    }
+}

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/ProtocolProvider.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/ProtocolProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Modifications Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2.0, as published by the
+ * Free Software Foundation.
+ *
+ * This program is also distributed with certain software (including but not
+ * limited to OpenSSL) that is licensed under separate terms, as designated in a
+ * particular file or component or in included license documentation. The
+ * authors of MySQL hereby grant you an additional permission to link the
+ * program and your derivative works with the separately licensed software that
+ * they have included with MySQL.
+ *
+ * Without limiting anything contained in the foregoing, this file, which is
+ * part of MySQL Connector/J, is also subject to the Universal FOSS Exception,
+ * version 1.0, a copy of which can be found at
+ * http://oss.oracle.com/licenses/universal-foss-exception.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License, version 2.0,
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+package com.mysql.cj.protocol.a;
+
+import com.mysql.cj.Session;
+import com.mysql.cj.TransactionEventHandler;
+import com.mysql.cj.conf.PropertySet;
+import com.mysql.cj.log.Log;
+import com.mysql.cj.protocol.Message;
+import com.mysql.cj.protocol.Protocol;
+import com.mysql.cj.protocol.SocketConnection;
+
+public interface ProtocolProvider {
+
+    /**
+     * Use a physical connection to create a protocol
+     *
+     * @param session
+     *          {@link Session}
+     * @param socketConnection
+     *          {@link SocketConnection}
+     * @param propertySet
+     *          {@link PropertySet}
+     * @param log
+     *          {@link Log}
+     * @param transactionManager
+     *          {@link TransactionEventHandler}
+     * @return {@link Protocol}
+     */
+    Protocol<? extends Message> getProtocolInstance(Session session, SocketConnection socketConnection, PropertySet propertySet, Log log,
+                                                    TransactionEventHandler transactionManager);
+
+}

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/SocketConnectionProvider.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/SocketConnectionProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Modifications Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2.0, as published by the
+ * Free Software Foundation.
+ *
+ * This program is also distributed with certain software (including but not
+ * limited to OpenSSL) that is licensed under separate terms, as designated in a
+ * particular file or component or in included license documentation. The
+ * authors of MySQL hereby grant you an additional permission to link the
+ * program and your derivative works with the separately licensed software that
+ * they have included with MySQL.
+ *
+ * Without limiting anything contained in the foregoing, this file, which is
+ * part of MySQL Connector/J, is also subject to the Universal FOSS Exception,
+ * version 1.0, a copy of which can be found at
+ * http://oss.oracle.com/licenses/universal-foss-exception.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License, version 2.0,
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+package com.mysql.cj.protocol.a;
+
+import com.mysql.cj.Session;
+import com.mysql.cj.protocol.Protocol;
+import com.mysql.cj.protocol.SocketConnection;
+
+public interface SocketConnectionProvider {
+    /**
+     * Get a {@link SocketConnection} to be used in a {@link Session}
+     *
+     * @return {@link Protocol}
+     */
+    SocketConnection getSocketConnection();
+
+}

--- a/src/test/java/com/mysql/cj/NativeSessionTest.java
+++ b/src/test/java/com/mysql/cj/NativeSessionTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Modifications Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2.0, as published by the
+ * Free Software Foundation.
+ *
+ * This program is also distributed with certain software (including but not
+ * limited to OpenSSL) that is licensed under separate terms, as designated in a
+ * particular file or component or in included license documentation. The
+ * authors of MySQL hereby grant you an additional permission to link the
+ * program and your derivative works with the separately licensed software that
+ * they have included with MySQL.
+ *
+ * Without limiting anything contained in the foregoing, this file, which is
+ * part of MySQL Connector/J, is also subject to the Universal FOSS Exception,
+ * version 1.0, a copy of which can be found at
+ * http://oss.oracle.com/licenses/universal-foss-exception.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License, version 2.0,
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+package com.mysql.cj;
+
+import com.mysql.cj.conf.HostInfo;
+import com.mysql.cj.conf.PropertySet;
+import com.mysql.cj.exceptions.CJCommunicationsException;
+import com.mysql.cj.jdbc.JdbcPropertySetImpl;
+import com.mysql.cj.log.Log;
+import com.mysql.cj.protocol.*;
+import com.mysql.cj.protocol.a.*;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+public class NativeSessionTest {
+    @Test
+    public void testExecSql_EOFExceptionThrowsCjCommunicationsException() throws IOException {
+        ProtocolEntityFactory mockFactory = Mockito.mock(ProtocolEntityFactory.class);
+        ColumnDefinition mockDefinition = Mockito.mock(ColumnDefinition.class);
+        TransactionEventHandler mockTransactionManager = Mockito.mock(TransactionEventHandler.class);
+        NativeProtocolProvider mockProtocolProvider = Mockito.mock(NativeProtocolProvider.class);
+        NativeProtocol mockProtocol = Mockito.mock(NativeProtocol.class);
+        SocketConnectionProvider mockSocketProvider = Mockito.mock(SocketConnectionProvider.class);
+        SocketConnection mockSocket = Mockito.mock(SocketConnection.class);
+
+        when(mockProtocol.getServerSession()).thenReturn(Mockito.mock(NativeServerSession.class));
+        when(mockProtocol.getAuthenticationProvider()).thenReturn(Mockito.mock(AuthenticationProvider.class));
+
+        HostInfo host = new HostInfo(null, "host-endpoint", 1234, null, null);
+        PropertySet props = new JdbcPropertySetImpl();
+        NativeSession testSession = new NativeSession(host, props, mockProtocolProvider, mockSocketProvider);
+
+        Query mockQuery = Mockito.mock(Query.class);
+        String sqlQuery = "SELECT * FROM arbitrary";
+        when(mockProtocolProvider.getProtocolInstance(eq(testSession), any(SocketConnection.class), eq(props), any(Log.class), eq(mockTransactionManager))).thenReturn(mockProtocol);
+        when(mockProtocol.sendQueryString(eq(mockQuery), eq(sqlQuery), nullable(String.class), eq(-1), eq(false), eq(mockDefinition), eq(mockFactory))).thenThrow(EOFException.class);
+        when(mockSocketProvider.getSocketConnection()).thenReturn(mockSocket);
+
+        testSession.connect(host, "", "", "", 30000,  mockTransactionManager);
+
+        assertThrows(
+                CJCommunicationsException.class,
+                () -> testSession.execSQL(mockQuery, sqlQuery, -1, null, false, mockFactory, mockDefinition, false));
+    }
+
+}


### PR DESCRIPTION
### Summary

Throw a communications exception instead of a generic one if the connection goes down during a long running query.