### PR TITLE
loop until successful

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareReaderFailoverHandler.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareReaderFailoverHandler.java
@@ -126,9 +126,9 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
     ExecutorService executor = Executors.newSingleThreadExecutor();
     Future<ConnectionAttemptResult> future = executor.submit(() -> {
       ConnectionAttemptResult result = null;
-      while(result == null) {
+      while(result == null || !result.isSuccess()) {
         result = failoverInternal(hosts, currentHost);
-        TimeUnit.MILLISECONDS.sleep(1);
+        TimeUnit.SECONDS.sleep(1);
       }
       return result;
     });

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareReaderFailoverHandlerTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareReaderFailoverHandlerTest.java
@@ -192,7 +192,7 @@ public class ClusterAwareReaderFailoverHandlerTest {
     assertFalse(result.isSuccess());
     assertNull(result.getConnection());
     assertEquals(ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, result.getConnectionIndex());
-    verify(mockTopologyService, times(1)).addToDownHostList(eq(currentHost));
+    verify(mockTopologyService, atLeast(1)).addToDownHostList(eq(currentHost));
 
     final List<HostInfo> hosts = new ArrayList<>();
     result = target.failover(hosts, currentHost);
@@ -200,7 +200,7 @@ public class ClusterAwareReaderFailoverHandlerTest {
     assertNull(result.getConnection());
     assertEquals(ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, result.getConnectionIndex());
 
-    verify(mockTopologyService, times(2)).addToDownHostList(eq(currentHost));
+    verify(mockTopologyService, atLeast(2)).addToDownHostList(eq(currentHost));
   }
 
   @Test


### PR DESCRIPTION
### Summary

Driver's unable to make a reader connection.

### Description

When cluster has 2 node configuration and driver is connected to a reader, driver couldn't reconnect to new reader in case of cluster failover.

### Related Issue

RDS-355

### Additional Reviewers

@congoamz 
@hsuamz 
@seneramz 