### PR TITLE
Improve integration tests timeouts

### DIFF
--- a/src/test/java/testsuite/regression/CachedRowsetTest.java
+++ b/src/test/java/testsuite/regression/CachedRowsetTest.java
@@ -53,7 +53,7 @@ public class CachedRowsetTest extends BaseTestCase {
      */
     @Test
     public void testBug5188() throws Exception {
-        String implClass = com.sun.rowset.CachedRowSetImpl.class.getName();
+        String implClass = "com.sun.rowset.CachedRowSetImpl";
         Class<?> c;
         Method populate;
         try {

--- a/src/test/java/testsuite/regression/ResultSetRegressionTest.java
+++ b/src/test/java/testsuite/regression/ResultSetRegressionTest.java
@@ -4006,7 +4006,7 @@ public class ResultSetRegressionTest extends BaseTestCase {
 
         this.rs = this.stmt.executeQuery("select firstName as 'first person' from bug49516");
 
-        crs = (CachedRowSet) Class.forName(com.sun.rowset.CachedRowSetImpl.class.getName()).newInstance();
+        crs = (CachedRowSet) Class.forName("com.sun.rowset.CachedRowSetImpl").newInstance();
         crs.populate(this.rs);
         crs.first();
 
@@ -4042,7 +4042,7 @@ public class ResultSetRegressionTest extends BaseTestCase {
 
         this.rs = noBlobsConn.createStatement().executeQuery("SELECT PASSWORD ('SOMETHING')");
 
-        crs = (CachedRowSet) Class.forName(com.sun.rowset.CachedRowSetImpl.class.getName()).newInstance();
+        crs = (CachedRowSet) Class.forName("com.sun.rowset.CachedRowSetImpl").newInstance();
         crs.populate(this.rs);
         crs.first();
 


### PR DESCRIPTION
### Summary

Improve integration tests timeouts

### Description

Use sockets blocking communication to db cluster instances instead of repeatedly running fault injection SQL.

### Related Issue

RDS-381

### Additional Reviewers

@congoamz 
@samathaamz 
@seneramz 
@hsuamz 
