### PR TITLE
Handle topology queries that don't return a writer

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,10 +6,6 @@
 
 <!--- Details of what you changed -->
 
-### Related Issue
-
-<!--- Link to issue where this is tracked -->
-
 ### Additional Reviewers
 
 <!-- Any additional reviewers -->

--- a/src/main/core-api/java/com/mysql/cj/util/Util.java
+++ b/src/main/core-api/java/com/mysql/cj/util/Util.java
@@ -508,4 +508,8 @@ public class Util {
             throw ExceptionFactory.createException(Messages.getString("Util.5") + ex.getClass().getName(), exceptionInterceptor);
         }
     }
+
+    public static boolean isNullOrEmpty(List<?> list) {
+        return list == null || list.isEmpty();
+    }
 }

--- a/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
+++ b/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
@@ -999,6 +999,7 @@ ConnectionProperties.acceptAwsProtocolOnly=Set to true to only accept connection
 
 AuroraTopologyService.1=[AuroraTopologyService] clusterId=''{0}''
 AuroraTopologyService.2=[AuroraTopologyService] clusterInstance host=''{0}'', port={1,number,#}, database=''{2}''
+AuroraTopologyService.3=[AuroraTopologyService] The topology query returned an invalid topology - no writer instance detected
 
 ClusterAwareConnectionProxy.1=Transaction resolution unknown. Please re-configure session state if required and try restarting transaction.
 ClusterAwareConnectionProxy.2=Unable to establish SQL connection to writer node.
@@ -1020,6 +1021,7 @@ ClusterAwareConnectionProxy.17=[ClusterAwareConnectionProxy] Starting reader fai
 ClusterAwareConnectionProxy.18=RDS Custom Cluster endpoint can't be used as an instance pattern.
 ClusterAwareConnectionProxy.19=The active SQL connection has changed. Please re-configure session state if required.
 ClusterAwareConnectionProxy.20=The provided connection string does not appear to match an expected Aurora DNS pattern. Please set the 'clusterInstanceHostPattern' configuration property to specify the host pattern for the cluster you are trying to connect to.
+ClusterAwareConnectionProxy.21=[ClusterAwareConnectionProxy] Cannot pick a new connection because the current host list is invalid (null or empty)
 
 ClusterAwareWriterFailoverHandler.1=Thread was interrupted.
 ClusterAwareWriterFailoverHandler.2=[ClusterAwareWriterFailoverHandler] Successfully re-connected to the current writer instance: ''{0}''
@@ -1027,7 +1029,7 @@ ClusterAwareWriterFailoverHandler.3=[ClusterAwareWriterFailoverHandler] Failed t
 ClusterAwareWriterFailoverHandler.4=[ClusterAwareWriterFailoverHandler] Successfully connected to the new writer instance: ''{0}''
 ClusterAwareWriterFailoverHandler.5=[ClusterAwareWriterFailoverHandler] {0} successfully established a connection but doesn't contain a valid topology
 ClusterAwareWriterFailoverHandler.6=[ClusterAwareWriterFailoverHandler] [TaskA] Attempting to re-connect to the current writer instance: ''{0}''
-ClusterAwareWriterFailoverHandler.7=[ClusterAwareWriterFailoverHandler] Failover was called with a null topology
+ClusterAwareWriterFailoverHandler.7=[ClusterAwareWriterFailoverHandler] Failover was called with an invalid (null or empty) topology
 ClusterAwareWriterFailoverHandler.8=[ClusterAwareWriterFailoverHandler] [TaskA] Finished
 ClusterAwareWriterFailoverHandler.9=[ClusterAwareWriterFailoverHandler] [TaskB] Attempting to connect to a new writer instance
 ClusterAwareWriterFailoverHandler.10=[ClusterAwareWriterFailoverHandler] [TaskB] Finished
@@ -1042,3 +1044,4 @@ ClusterAwareReaderFailoverHandler.2=[ClusterAwareReaderFailoverHandler] Connecte
 ClusterAwareReaderFailoverHandler.3=[ClusterAwareReaderFailoverHandler] Trying to connect to reader [{0,number,#}] ''{1}''
 ClusterAwareReaderFailoverHandler.4=[ClusterAwareReaderFailoverHandler] Connected to reader [{0,number,#}] ''{1}''
 ClusterAwareReaderFailoverHandler.5=[ClusterAwareReaderFailoverHandler] Failed to connect to reader [{0,number,#}] ''{1}''
+ClusterAwareReaderFailoverHandler.6=[ClusterAwareReaderFailoverHandler] {0} was called with an invalid (null or empty) topology

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/AuroraTopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/AuroraTopologyService.java
@@ -321,6 +321,7 @@ public class AuroraTopologyService implements TopologyService, CanCollectPerform
     } else {
       clusterTopologyInfo.hosts = latestTopologyInfo.hosts;
       clusterTopologyInfo.downHosts = latestTopologyInfo.downHosts;
+      clusterTopologyInfo.isMultiWriterCluster = latestTopologyInfo.isMultiWriterCluster;
     }
     clusterTopologyInfo.lastUpdated = Instant.now();
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
@@ -680,12 +680,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
       return;
     }
 
-    if(Util.isNullOrEmpty(this.hosts)) {
-      this.log.logDebug("ClusterAwareConnectionProxy.21");
-      return;
-    }
-
-    if (isConnected()) {
+    if (isConnected() || Util.isNullOrEmpty(this.hosts)) {
       failover(this.currentHostIndex);
       return;
     }
@@ -902,7 +897,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     this.log.logDebug(Messages.getString("ClusterAwareConnectionProxy.17"));
 
     HostInfo failedHost = null;
-    if(failedHostIdx != NO_CONNECTION_INDEX && !Util.isNullOrEmpty(this.hosts)) {
+    if (failedHostIdx != NO_CONNECTION_INDEX && !Util.isNullOrEmpty(this.hosts)) {
       failedHost = this.hosts.get(failedHostIdx);
     }
     ReaderFailoverResult result = readerFailoverHandler.failover(this.hosts, failedHost);

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
@@ -569,6 +569,10 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
   }
 
   private int getCandidateIndexForInitialConnection() {
+    if(Util.isNullOrEmpty(this.hosts)) {
+      return NO_CONNECTION_INDEX;
+    }
+
     if (isExplicitlyReadOnly()) {
       int candidateReaderIndex = getCandidateReaderForInitialConnection();
       if (candidateReaderIndex != NO_CONNECTION_INDEX) {
@@ -724,7 +728,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
                 new StringBuilder("Connection to ")
                         .append(isWriterHostIndex(hostIndex) ? "writer" : "reader")
                         .append(" host '")
-                        .append(host.getHostPortPair())
+                        .append(host == null ? "<null>" : host.getHostPortPair())
                         .append("' failed");
         try {
           this.log.logWarn(msg.toString(), e);
@@ -859,7 +863,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
       this.failoverStartTimeMs = 0;
     }
 
-    if (!failoverResult.isConnected()) {
+    if (failoverResult == null || !failoverResult.isConnected()) {
       // "Unable to establish SQL connection to writer node"
       processFailoverFailure(Messages.getString("ClusterAwareConnectionProxy.2"));
       return;
@@ -908,7 +912,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
       this.failoverStartTimeMs = 0;
     }
 
-    if (!result.isConnected()) {
+    if (result == null || !result.isConnected()) {
       // "Unable to establish SQL connection to reader node"
       processFailoverFailure(Messages.getString("ClusterAwareConnectionProxy.4"));
       return;
@@ -1320,7 +1324,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
       msg.append("\n   [")
               .append(i)
               .append("]: ")
-              .append(hostInfo.getHost());
+              .append(hostInfo == null ? "<null>" : hostInfo.getHost());
     }
     this.log.logTrace(
         Messages.getString("ClusterAwareConnectionProxy.11", new Object[] {msg.toString()}));

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
@@ -930,13 +930,11 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
 
     if(this.currentHostIndex != NO_CONNECTION_INDEX && !Util.isNullOrEmpty(this.hosts)) {
       HostInfo currentHost = this.hosts.get(this.currentHostIndex);
+      topologyService.setLastUsedReaderHost(currentHost);
       this.log.logDebug(
               Messages.getString(
                       "ClusterAwareConnectionProxy.15",
                       new Object[] {currentHost}));
-      if (currentHost != null) {
-        topologyService.setLastUsedReaderHost(currentHost);
-      }
     }
   }
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
@@ -54,6 +54,7 @@ import com.mysql.cj.log.LogFactory;
 import com.mysql.cj.log.NullLogger;
 import com.mysql.cj.util.IpAddressUtils;
 import com.mysql.cj.util.StringUtils;
+import com.mysql.cj.util.Util;
 
 import javax.net.ssl.SSLException;
 import java.io.EOFException;
@@ -61,6 +62,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -117,7 +119,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
   protected boolean isRdsProxy = false;
   protected boolean isRds = false;
   protected TopologyService topologyService;
-  protected List<HostInfo> hosts;
+  protected List<HostInfo> hosts = new ArrayList<>();
   protected WriterFailoverHandler writerFailoverHandler;
   protected ReaderFailoverHandler readerFailoverHandler;
   protected ConnectionProvider connectionProvider;
@@ -486,10 +488,14 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     initTopology();
     if (this.isFailoverEnabled()) {
       validateInitialConnection();
-      HostInfo currentHost = this.hosts.get(this.currentHostIndex);
-      if (currentHost != null && isExplicitlyReadOnly()) {
-        topologyService.setLastUsedReaderHost(currentHost);
+
+      if(this.currentHostIndex != NO_CONNECTION_INDEX && !Util.isNullOrEmpty(this.hosts)) {
+        HostInfo currentHost = this.hosts.get(this.currentHostIndex);
+        if (isExplicitlyReadOnly()) {
+          topologyService.setLastUsedReaderHost(currentHost);
+        }
       }
+
       this.currentConnection.getPropertySet().getIntegerProperty(PropertyKey.socketTimeout).setValue(this.failoverSocketTimeoutMs);
       ((NativeSession) this.currentConnection.getSession()).setSocketTimeout(this.failoverSocketTimeoutMs);
     }
@@ -543,14 +549,15 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
   }
 
   private void attemptConnectionUsingCachedTopology() throws SQLException {
-    this.hosts = topologyService.getCachedTopology();
-    if (this.hosts == null || this.hosts.isEmpty()) {
+    List<HostInfo> cachedHosts = topologyService.getCachedTopology();
+    if (Util.isNullOrEmpty(cachedHosts)) {
       if (this.gatherPerfMetricsSetting) {
         this.metrics.registerUseCachedTopology(false);
       }
       return;
     }
 
+    this.hosts = cachedHosts;
     if (this.gatherPerfMetricsSetting) {
       this.metrics.registerUseCachedTopology(true);
     }
@@ -568,7 +575,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
         return candidateReaderIndex;
       }
     }
-    return this.hosts.get(WRITER_CONNECTION_INDEX) != null ? WRITER_CONNECTION_INDEX : NO_CONNECTION_INDEX;
+    return WRITER_CONNECTION_INDEX;
   }
 
   private int getCandidateReaderForInitialConnection() {
@@ -602,13 +609,19 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
   }
 
   private synchronized void initTopology() {
-    this.hosts = this.topologyService.getTopology(this.currentConnection, false);
-    this.isClusterTopologyAvailable = this.hosts != null && !this.hosts.isEmpty();
-    this.isMultiWriterCluster = this.topologyService.isMultiWriterCluster();
+    if(this.currentConnection != null) {
+      List<HostInfo> topology = this.topologyService.getTopology(this.currentConnection, false);
+      if (!Util.isNullOrEmpty(topology)) {
+        this.hosts = topology;
+      }
+    }
+
+    this.isClusterTopologyAvailable = !Util.isNullOrEmpty(this.hosts);
     this.log.logTrace(
             Messages.getString(
                     "ClusterAwareConnectionProxy.10",
                     new Object[] {"isClusterTopologyAvailable", this.isClusterTopologyAvailable}));
+    this.isMultiWriterCluster = this.topologyService.isMultiWriterCluster();
 
     if (this.isFailoverEnabled()) {
       logTopology();
@@ -633,14 +646,6 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
       this.metrics.registerInvalidInitialConnection(true);
     }
 
-    if (this.hosts.get(WRITER_CONNECTION_INDEX) == null) {
-      if (this.gatherPerfMetricsSetting) {
-        this.failoverStartTimeMs = System.currentTimeMillis();
-      }
-      failover(WRITER_CONNECTION_INDEX);
-      return;
-    }
-
     try {
       connectTo(WRITER_CONNECTION_INDEX);
     } catch (SQLException e) {
@@ -652,9 +657,10 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
   }
 
   private int getHostIndex(HostInfo host) {
-    if (host == null) {
+    if (host == null || Util.isNullOrEmpty(this.hosts)) {
       return NO_CONNECTION_INDEX;
     }
+
     for (int i = 0; i < this.hosts.size(); i++) {
       HostInfo potentialMatch = this.hosts.get(i);
       if (potentialMatch != null && potentialMatch.equalHostPortPair(host)) {
@@ -674,6 +680,11 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
       return;
     }
 
+    if(Util.isNullOrEmpty(this.hosts)) {
+      this.log.logDebug("ClusterAwareConnectionProxy.21");
+      return;
+    }
+
     if (isConnected()) {
       failover(this.currentHostIndex);
       return;
@@ -684,14 +695,9 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
       return;
     }
 
-    if (this.hosts.get(WRITER_CONNECTION_INDEX) == null) {
-      failover(WRITER_CONNECTION_INDEX);
-      return;
-    }
-
     try {
       connectTo(WRITER_CONNECTION_INDEX);
-      if (isExplicitlyReadOnly()) {
+      if (isExplicitlyReadOnly() && this.currentHostIndex != NO_CONNECTION_INDEX) {
         topologyService.setLastUsedReaderHost(this.hosts.get(this.currentHostIndex));
       }
     } catch (SQLException e) {
@@ -723,7 +729,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
                 new StringBuilder("Connection to ")
                         .append(isWriterHostIndex(hostIndex) ? "writer" : "reader")
                         .append(" host '")
-                        .append(host == null ? "<null>" : host.getHostPortPair())
+                        .append(host.getHostPortPair())
                         .append("' failed");
         try {
           this.log.logWarn(msg.toString(), e);
@@ -858,13 +864,13 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
       this.failoverStartTimeMs = 0;
     }
 
-    if (failoverResult == null || !failoverResult.isConnected()) {
+    if (!failoverResult.isConnected()) {
       // "Unable to establish SQL connection to writer node"
       processFailoverFailure(Messages.getString("ClusterAwareConnectionProxy.2"));
       return;
     }
 
-    if (failoverResult.isNewHost()) {
+    if (!Util.isNullOrEmpty(failoverResult.getTopology())) {
       this.hosts = failoverResult.getTopology();
     }
 
@@ -895,8 +901,10 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
   protected void failoverReader(int failedHostIdx) throws SQLException {
     this.log.logDebug(Messages.getString("ClusterAwareConnectionProxy.17"));
 
-    HostInfo failedHost =
-            failedHostIdx == NO_CONNECTION_INDEX ? null : this.hosts.get(failedHostIdx);
+    HostInfo failedHost = null;
+    if(failedHostIdx != NO_CONNECTION_INDEX && !Util.isNullOrEmpty(this.hosts)) {
+      failedHost = this.hosts.get(failedHostIdx);
+    }
     ReaderFailoverResult result = readerFailoverHandler.failover(this.hosts, failedHost);
 
     if (this.gatherPerfMetricsSetting) {
@@ -905,9 +913,10 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
       this.failoverStartTimeMs = 0;
     }
 
-    if (result == null || !result.isConnected()) {
+    if (!result.isConnected()) {
       // "Unable to establish SQL connection to reader node"
       processFailoverFailure(Messages.getString("ClusterAwareConnectionProxy.4"));
+      return;
     }
 
     if (this.gatherPerfMetricsSetting) {
@@ -918,28 +927,31 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     setConnectionProxy(this.currentConnection);
     this.currentHostIndex = result.getConnectionIndex();
     updateTopologyAndConnectIfNeeded(true);
-    this.log.logDebug(
-            Messages.getString(
-                    "ClusterAwareConnectionProxy.15",
-                    new Object[] {this.hosts.get(this.currentHostIndex)}));
-    HostInfo currentHost = this.hosts.get(this.currentHostIndex);
-    if (currentHost != null) {
-      topologyService.setLastUsedReaderHost(currentHost);
+
+    if(this.currentHostIndex != NO_CONNECTION_INDEX && !Util.isNullOrEmpty(this.hosts)) {
+      HostInfo currentHost = this.hosts.get(this.currentHostIndex);
+      this.log.logDebug(
+              Messages.getString(
+                      "ClusterAwareConnectionProxy.15",
+                      new Object[] {currentHost}));
+      if (currentHost != null) {
+        topologyService.setLastUsedReaderHost(currentHost);
+      }
     }
   }
 
   protected void updateTopologyAndConnectIfNeeded(boolean forceUpdate) throws SQLException {
-    if (!isFailoverEnabled() || this.currentConnection.isClosed()) {
+    if (!isFailoverEnabled() || this.currentConnection == null || this.currentConnection.isClosed()) {
       return;
     }
 
     List<HostInfo> latestTopology = this.topologyService.getTopology(this.currentConnection, forceUpdate);
-    if (latestTopology == null) {
+    if (Util.isNullOrEmpty(latestTopology)) {
       return;
     }
 
+    this.hosts = latestTopology;
     if (!isConnected()) {
-      this.hosts = latestTopology;
       pickNewConnection();
       return;
     }
@@ -962,13 +974,11 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     if (latestHostIndex == NO_CONNECTION_INDEX) {
       // current connection host isn't found in the latest topology
       // switch to another connection;
-      this.hosts = latestTopology;
       this.currentHostIndex = NO_CONNECTION_INDEX;
       pickNewConnection();
     } else {
       // found the same node at different position in the topology
       // adjust current index only; connection is still valid
-      this.hosts = latestTopology;
       this.currentHostIndex = latestHostIndex;
     }
   }
@@ -1087,7 +1097,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
       dealWithIllegalStateException(e);
     }
 
-    performExtraActionsIfRequired(args, methodName);
+    performSpecialMethodHandlingIfRequired(args, methodName);
     return result;
   }
 
@@ -1106,7 +1116,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     } else {
       String reason = "No operations allowed after connection closed.";
       if (this.closedReason != null) {
-        reason += ("  " + this.closedReason);
+        reason += (" " + this.closedReason);
       }
       throw SQLError.createSQLException(reason, MysqlErrorNumbers.SQL_STATE_CONNECTION_NOT_OPEN, null /* no access to a interceptor here... */);
     }
@@ -1200,7 +1210,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
     super.invalidateConnection(this.currentConnection);
   }
 
-  private void performExtraActionsIfRequired(Object[] args, String methodName) throws SQLException {
+  private void performSpecialMethodHandlingIfRequired(Object[] args, String methodName) throws SQLException {
     if (METHOD_SET_AUTO_COMMIT.equals(methodName)) {
       this.explicitlyAutoCommit = (Boolean) args[0];
       this.inTransaction = !this.explicitlyAutoCommit;
@@ -1221,18 +1231,17 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
   }
 
   private void connectToWriterIfRequired(Boolean readOnly) throws SQLException {
-    if (readOnly != null && !readOnly && !isWriterHostIndex(this.currentHostIndex)) {
-      if (this.hosts.get(WRITER_CONNECTION_INDEX) == null) {
-        failover(WRITER_CONNECTION_INDEX);
-        return;
-      }
-
+    if (shouldReconnectToWriter(readOnly) && !Util.isNullOrEmpty(this.hosts)) {
       try {
         connectTo(WRITER_CONNECTION_INDEX);
       } catch (SQLException e) {
         failover(WRITER_CONNECTION_INDEX);
       }
     }
+  }
+
+  private boolean shouldReconnectToWriter(Boolean readOnly) {
+    return readOnly != null && !readOnly && !isWriterHostIndex(this.currentHostIndex);
   }
 
   /**
@@ -1318,7 +1327,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
       msg.append("\n   [")
               .append(i)
               .append("]: ")
-              .append(hostInfo == null ? "<null>" : hostInfo.getHost());
+              .append(hostInfo.getHost());
     }
     this.log.logTrace(
         Messages.getString("ClusterAwareConnectionProxy.11", new Object[] {msg.toString()}));

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareUtils.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareUtils.java
@@ -17,9 +17,14 @@ public class ClusterAwareUtils {
      * @param additionalProps The map of properties to add to the new {@link HostInfo} copy
      *
      * @return A copy of the given {@link HostInfo} object where all details are the same except for the host properties,
-     *      will contain both the original properties and the properties passed into the function
+     *      will contain both the original properties and the properties passed into the function. Returns null if
+     *      baseHostInfo is null
      */
     public static HostInfo copyWithAdditionalProps(HostInfo baseHostInfo, Map<String, String> additionalProps) {
+        if (baseHostInfo == null || additionalProps == null) {
+            return baseHostInfo;
+        }
+
         DatabaseUrlContainer urlContainer = ConnectionUrl.getConnectionUrlInstance(baseHostInfo.getDatabaseUrl(), new Properties());
         Map<String, String> originalProps = baseHostInfo.getHostProperties();
         Map<String, String> mergedProps = new HashMap<>();

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareWriterFailoverHandler.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareWriterFailoverHandler.java
@@ -422,7 +422,7 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
         msg.append("\n   [")
             .append(i)
             .append("]: ")
-            .append(hostInfo.getHost());
+            .append(hostInfo == null ? "<null>" : hostInfo.getHost());
       }
       log.logTrace(
           Messages.getString(

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/TopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/TopologyService.java
@@ -74,7 +74,7 @@ public interface TopologyService {
    * @param forceUpdate If true, it forces a service to ignore cached copy of topology and to fetch
    *     a fresh one.
    * @return A list of hosts that describes cluster topology. A writer is always at position 0.
-   *     Returns null if topology isn't available.
+   *     Returns an empty list if topology isn't available or is invalid (doesn't contain a writer).
    */
   List<HostInfo> getTopology(JdbcConnection conn, boolean forceUpdate);
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/WriterFailoverHandler.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/WriterFailoverHandler.java
@@ -45,8 +45,7 @@ public interface WriterFailoverHandler {
    * Called to start Writer Failover Process.
    *
    * @param currentTopology Cluster current topology
-   * @return {@link WriterFailoverResult} The results of this process. May return null, which is
-   *     considered an unsuccessful result.
+   * @return {@link WriterFailoverResult} The results of this process.
    */
   WriterFailoverResult failover(List<HostInfo> currentTopology) throws SQLException;
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/WriterFailoverResult.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/WriterFailoverResult.java
@@ -41,6 +41,7 @@ public class WriterFailoverResult {
   private final boolean isNewHost;
   private final List<HostInfo> topology;
   private final JdbcConnection newConnection;
+  private final String taskName;
 
   /**
    * ResolvedHostInfo constructor.
@@ -49,11 +50,13 @@ public class WriterFailoverResult {
       boolean isConnected,
       boolean isNewHost,
       List<HostInfo> topology,
-      JdbcConnection newConnection) {
+      JdbcConnection newConnection,
+      String taskName) {
     this.isConnected = isConnected;
     this.isNewHost = isNewHost;
     this.topology = topology;
     this.newConnection = newConnection;
+    this.taskName = taskName;
   }
 
   /**
@@ -86,12 +89,21 @@ public class WriterFailoverResult {
   }
 
   /**
-   * Get connection to a host.
+   * Get the new connection established by the failover procedure if successful.
    *
-   * @return {@link JdbcConnection} New connection to a host. Returns null if no connection is
-   *     established.
+   * @return {@link JdbcConnection} New connection to a host. Returns null if the failover pocedure
+   *     was unsuccessful.
    */
   public JdbcConnection getNewConnection() {
     return this.newConnection;
+  }
+
+  /**
+   * Get the name of the writer failover task that created this result.
+   *
+   * @return The name of the writer failover task that created this result.
+   */
+  public String getTaskName() {
+    return this.taskName;
   }
 }

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/AuroraTopologyServiceTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/AuroraTopologyServiceTest.java
@@ -308,7 +308,7 @@ public class AuroraTopologyServiceTest {
     when(mockConn.createStatement()).thenThrow(SQLException.class);
 
     final List<HostInfo> hosts = spyProvider.getTopology(mockConn, true);
-    assertNull(hosts);
+    assertTrue(hosts.isEmpty());
   }
 
   @Test

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareReaderFailoverHandlerTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareReaderFailoverHandlerTest.java
@@ -192,15 +192,12 @@ public class ClusterAwareReaderFailoverHandlerTest {
     assertFalse(result.isConnected());
     assertNull(result.getConnection());
     assertEquals(ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, result.getConnectionIndex());
-    verify(mockTopologyService, atLeast(1)).addToDownHostList(eq(currentHost));
 
     final List<HostInfo> hosts = new ArrayList<>();
     result = target.failover(hosts, currentHost);
     assertFalse(result.isConnected());
     assertNull(result.getConnection());
     assertEquals(ClusterAwareConnectionProxy.NO_CONNECTION_INDEX, result.getConnectionIndex());
-
-    verify(mockTopologyService, atLeast(2)).addToDownHostList(eq(currentHost));
   }
 
   @Test

--- a/src/test/java/testsuite/failover/FailoverIntegrationTest.java
+++ b/src/test/java/testsuite/failover/FailoverIntegrationTest.java
@@ -164,7 +164,7 @@ public class FailoverIntegrationTest {
     failoverClusterAndWaitUntilWriterChanged(initialWriterId);
 
     // Failure occurs on Statement invocation
-    assertFirstQueryThrows(stmt, "08S02");
+    assertFirstQueryThrows(stmt);
 
     // Assert that the driver is connected to the new writer after failover happens.
     final String currentConnectionId = queryInstanceId(testConnection);
@@ -949,12 +949,12 @@ public class FailoverIntegrationTest {
     assertEquals(expectedSQLErrorCode, exception.getSQLState());
   }
 
-  private void assertFirstQueryThrows(Statement stmt, String expectedSQLErrorCode) {
+  private void assertFirstQueryThrows(Statement stmt) {
     this.log.logDebug(
             "Assert that the first read query throws, "
                     + "this should kick off the driver failover process..");
     SQLException exception = assertThrows(SQLException.class, () -> executeInstanceIdQuery(stmt));
-    assertEquals(expectedSQLErrorCode, exception.getSQLState());
+    assertEquals("08S02", exception.getSQLState());
   }
 
   @BeforeEach
@@ -1006,10 +1006,6 @@ public class FailoverIntegrationTest {
 
   protected void startCrashingInstances(String... instances) {
     instancesToCrash.addAll(Arrays.asList(instances));
-  }
-
-  protected void stopCrashingInstances(String... instances) {
-    instancesToCrash.removeAll(Arrays.asList(instances));
   }
 
   protected void makeSureInstancesUp(String... instances) throws InterruptedException {

--- a/src/test/java/testsuite/failover/FailoverIntegrationTest.java
+++ b/src/test/java/testsuite/failover/FailoverIntegrationTest.java
@@ -164,7 +164,7 @@ public class FailoverIntegrationTest {
     failoverClusterAndWaitUntilWriterChanged(initialWriterId);
 
     // Failure occurs on Statement invocation
-    assertFirstQueryThrows(stmt);
+    assertFirstQueryThrows(stmt, "08S02");
 
     // Assert that the driver is connected to the new writer after failover happens.
     final String currentConnectionId = queryInstanceId(testConnection);
@@ -949,12 +949,12 @@ public class FailoverIntegrationTest {
     assertEquals(expectedSQLErrorCode, exception.getSQLState());
   }
 
-  private void assertFirstQueryThrows(Statement stmt) {
+  private void assertFirstQueryThrows(Statement stmt, String expectedSQLErrorCode) {
     this.log.logDebug(
             "Assert that the first read query throws, "
                     + "this should kick off the driver failover process..");
     SQLException exception = assertThrows(SQLException.class, () -> executeInstanceIdQuery(stmt));
-    assertEquals("08S02", exception.getSQLState());
+    assertEquals(expectedSQLErrorCode, exception.getSQLState());
   }
 
   @BeforeEach


### PR DESCRIPTION
### Summary

Handle topology queries that don't return a writer

### Description

- also added guards against exceptions that might arise from calling this.hosts.get when this.hosts is null or empty, or this.hosts.get(this.currentHostIndex) when this.currentHostIndex == -1
- reader failover, writer failover, ClusterAwareReaderFailover#getReaderConnection, and AuroraTopologyService#getTopology never return null

### Additional Reviewers

@seneramz 
@sergiyv-bitquill 
@hsuamz 
@samathaamz 