### PR TITLE
fix: Fix source and target Java level not set to 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,12 @@ $ docker-compose down && docker-compose rm
 $ cd ../
 ```
 
+## Known Issues
+### SSLHandshakeException
+Using the driver with JDKs based on OpenJDK 8u292+ or OpenJDK 11.0.11+ will result in an exception: `SSLHandshakeException: No appropriate protocol`.
+This is due OpenJDK disabling TLS 1.0 and 1.1 availability in `security.properties`, for additional information see "[Disable TLS 1.0 and TLS 1.1](https://java.com/en/configure_crypto.html#DisableTLS)".
+To resolve this exception, add the `enabledTLSProtocols=TLSv1.2` connection property when connecting to a database.
+
 ## Getting Help and Opening Issues
 
 If you encounter a bug with the AWS JDBC Driver for MySQL, we would like to hear about it. Please search the [existing issues](https://github.com/awslabs/aws-mysql-jdbc/issues) and see if others are also experiencing the issue before opening a new issue. When opening a new issue, we will need the version of AWS JDBC Driver for MySQL, Java language version, OS you’re using, and the MySQL database version you're running against. Please also include reproduction case for the issue when appropriate.

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ $ cd ../
 ## Known Issues
 ### SSLHandshakeException
 Using the driver with JDKs based on OpenJDK 8u292+ or OpenJDK 11.0.11+ will result in an exception: `SSLHandshakeException: No appropriate protocol`.
-This is due OpenJDK disabling TLS 1.0 and 1.1 availability in `security.properties`, for additional information see "[Disable TLS 1.0 and TLS 1.1](https://java.com/en/configure_crypto.html#DisableTLS)".
+This is due to OpenJDK disabling TLS 1.0 and 1.1 availability in `security.properties`, for additional information see "[Disable TLS 1.0 and TLS 1.1](https://java.com/en/configure_crypto.html#DisableTLS)".
 To resolve this exception, add the `enabledTLSProtocols=TLSv1.2` connection property when connecting to a database.
 
 ## Getting Help and Opening Issues

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,8 @@ plugins {
 java {
     withJavadocJar()
     withSourcesJar()
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 checkstyle {
@@ -110,14 +112,6 @@ tasks.shadowJar {
 
     from("${buildDir}/META-INF/services/") {
         into("META-INF/services/")
-    }
-
-    doFirst {
-        mkdir("${buildDir}/META-INF/services/")
-        val driverFile = File("${buildDir}/META-INF/services/java.sql.Driver")
-        if(driverFile.createNewFile()) {
-            driverFile.writeText("software.aws.rds.jdbc.mysql.Driver")
-        }
     }
 
     dependencies {

--- a/src/main/resources/META-INF/services/java.sql.Driver
+++ b/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,1 @@
+software.aws.rds.jdbc.mysql.Driver

--- a/src/main/user-impl/java/software/aws/rds/jdbc/mysql/Driver.java
+++ b/src/main/user-impl/java/software/aws/rds/jdbc/mysql/Driver.java
@@ -32,6 +32,7 @@ package software.aws.rds.jdbc.mysql;
 
 import com.mysql.cj.jdbc.NonRegisteringDriver;
 
+import java.sql.DriverManager;
 import java.sql.SQLException;
 
 /**
@@ -49,13 +50,14 @@ import java.sql.SQLException;
  * When a Driver class is loaded, it should create an instance of itself and register it with the DriverManager. This means that a user can load and register a
  * driver by doing Class.forName("foo.bah.Driver")
  */
-public class Driver extends NonRegisteringDriver implements java.sql.Driver {
+public class Driver extends NonRegisteringDriver {
   //
   // Register ourselves with the DriverManager
   //
   static {
     try {
-      java.sql.DriverManager.registerDriver(new Driver());
+      DriverManager.registerDriver(new Driver());
+      System.out.println("You are using Amazon Web Services (AWS) JDBC Driver for MySQL.");
     } catch (SQLException E) {
       throw new RuntimeException("Can't register driver!");
     }
@@ -73,10 +75,6 @@ public class Driver extends NonRegisteringDriver implements java.sql.Driver {
    */
   public static void setAcceptAwsProtocolOnly(boolean awsProtocolOnly) {
     acceptAwsProtocolOnly = awsProtocolOnly;
-  }
-
-  static {
-    System.out.println("You are using Amazon Web Services (AWS) JDBC Driver for MySQL, you can also use 'software.aws.rds.jdbc.mysql.Driver()' to register");
   }
 
   /**


### PR DESCRIPTION
### Summary

Fix source and target Java level not set to 8

### Description

- Set the `sourceCompatibility` and the `targetCompatibility` values to Java 1.8 so project compiles to Java 8.
- Remove `you can also use 'software.aws.rds.jdbc.mysql.Driver()' to register`, this line is only printed when the driver has been registered.
- Remove `implements Driver` since `NonRegisteringDriver` already implements it.

### Additional Reviewers

@sergiyv-bitquill 
@hsuamz 
@congoamz 