### PR TITLE
fix: Using an invalid connection after valid

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxy.java
@@ -805,7 +805,7 @@ public class ClusterAwareConnectionProxy extends MultiHostConnectionProxy
   @Override
   protected synchronized ConnectionImpl createConnectionForHost(HostInfo baseHostInfo)
           throws SQLException {
-    HostInfo hostInfoWithInitialProps = ClusterAwareUtils.copyWithAdditionalProps(baseHostInfo, this.initialConnectionProps);
+    HostInfo hostInfoWithInitialProps = ClusterAwareUtils.copyWithAdditionalProps(baseHostInfo, this.connectionUrl);
     ConnectionImpl conn = this.connectionProvider.connect(hostInfoWithInitialProps);
     setConnectionProxy(conn);
     return conn;

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareUtils.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareUtils.java
@@ -62,4 +62,35 @@ public class ClusterAwareUtils {
         mergedProps.putAll(additionalProps);
         return new HostInfo(urlContainer, baseHostInfo.getHost(), baseHostInfo.getPort(), baseHostInfo.getUser(), baseHostInfo.getPassword(), mergedProps);
     }
+
+    /**
+     * Create a copy of {@link HostInfo} object where host and port are the same while all others are from {@link ConnectionUrl} object
+     *
+     * @param baseHostInfo The {@link HostInfo} object to copy host and port from
+     * @param connectionUrl All other properties to add to the new {@link HostInfo}
+     *
+     * @return A copy of {@link HostInfo} object where host and port are the same while all others are from {@link ConnectionUrl} object
+     *      Returns baseHostInfo if connectionUrl is null
+     *      Returns connectionUrl's HostInfo if baseHostInfo is null
+     */
+    public static HostInfo copyWithAdditionalProps(HostInfo baseHostInfo, ConnectionUrl connectionUrl) {
+        if (connectionUrl == null) {
+            return baseHostInfo;
+        }
+
+        final HostInfo mainHost = connectionUrl.getMainHost();
+        if (baseHostInfo == null) {
+            return mainHost;
+        }
+
+        DatabaseUrlContainer urlContainer = ConnectionUrl.getConnectionUrlInstance(baseHostInfo.getDatabaseUrl(), new Properties());
+        Map<String, String> originalProps = baseHostInfo.getHostProperties();
+        Map<String, String> mergedProps = new HashMap<>();
+        mergedProps.putAll(originalProps);
+        mergedProps.putAll(mainHost.getHostProperties());
+
+        return new HostInfo(urlContainer, baseHostInfo.getHost(), baseHostInfo.getPort(),
+            mainHost.getUser(), mainHost.getPassword(),
+            mergedProps);
+    }
 }

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxyTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareConnectionProxyTest.java
@@ -114,7 +114,7 @@ public class ClusterAwareConnectionProxyTest {
     final List<HostInfo> mockTopology = new ArrayList<>();
     mockTopology.add(writerHost);
     when(mockTopologyService.getTopology(eq(mockConn), any(Boolean.class)))
-            .thenReturn(mockTopology);
+        .thenReturn(mockTopology);
     when(mockTopologyService.getHostByName(mockConn)).thenReturn(writerHost);
 
     final ClusterAwareConnectionProxy proxy =
@@ -140,13 +140,13 @@ public class ClusterAwareConnectionProxyTest {
         .thenReturn(localSessionState);
 
     final RuntimeProperty<Integer> connectTimeout =
-            new IntegerPropertyDefinition(PropertyKey.connectTimeout, 0, true, Messages.getString("ConnectionProperties.connectTimeout"),
-                    "0.1.0", PropertyDefinitions.CATEGORY_NETWORK, 9, 0, Integer.MAX_VALUE).createRuntimeProperty();
+        new IntegerPropertyDefinition(PropertyKey.connectTimeout, 0, true, Messages.getString("ConnectionProperties.connectTimeout"),
+            "0.1.0", PropertyDefinitions.CATEGORY_NETWORK, 9, 0, Integer.MAX_VALUE).createRuntimeProperty();
     when(mockPropertySet.getIntegerProperty(PropertyKey.connectTimeout)).thenReturn(connectTimeout);
 
     final RuntimeProperty<Integer> socketTimeout =
-            new IntegerPropertyDefinition(PropertyKey.socketTimeout, 0, true, Messages.getString("ConnectionProperties.socketTimeout"),
-                    "0.1.0", PropertyDefinitions.CATEGORY_NETWORK, 10, 0, Integer.MAX_VALUE).createRuntimeProperty();
+        new IntegerPropertyDefinition(PropertyKey.socketTimeout, 0, true, Messages.getString("ConnectionProperties.socketTimeout"),
+            "0.1.0", PropertyDefinitions.CATEGORY_NETWORK, 10, 0, Integer.MAX_VALUE).createRuntimeProperty();
     when(mockPropertySet.getIntegerProperty(PropertyKey.socketTimeout)).thenReturn(socketTimeout);
   }
 
@@ -190,7 +190,7 @@ public class ClusterAwareConnectionProxyTest {
     final List<HostInfo> mockTopology = new ArrayList<>();
     mockTopology.add(writerHost);
     when(mockTopologyService.getTopology(eq(mockConn), any(Boolean.class)))
-            .thenReturn(mockTopology);
+        .thenReturn(mockTopology);
     when(mockTopologyService.getHostByName(mockConn)).thenReturn(writerHost);
 
     assertThrows(
@@ -222,7 +222,7 @@ public class ClusterAwareConnectionProxyTest {
     final List<HostInfo> mockTopology = new ArrayList<>();
     mockTopology.add(writerHost);
     when(mockTopologyService.getTopology(eq(mockConn), any(Boolean.class)))
-            .thenReturn(mockTopology);
+        .thenReturn(mockTopology);
     when(mockTopologyService.getHostByName(mockConn)).thenReturn(writerHost);
 
     final WriterFailoverHandler writerFailoverHandler = Mockito.mock(WriterFailoverHandler.class);
@@ -267,7 +267,7 @@ public class ClusterAwareConnectionProxyTest {
     final List<HostInfo> mockTopology = new ArrayList<>();
     mockTopology.add(writerHost);
     when(mockTopologyService.getTopology(eq(mockConn), any(Boolean.class)))
-            .thenReturn(mockTopology);
+        .thenReturn(mockTopology);
     when(mockTopologyService.getHostByName(mockConn)).thenReturn(writerHost);
 
     final WriterFailoverHandler writerFailoverHandler = Mockito.mock(WriterFailoverHandler.class);
@@ -312,7 +312,7 @@ public class ClusterAwareConnectionProxyTest {
     final List<HostInfo> mockTopology = new ArrayList<>();
     mockTopology.add(writerHost);
     when(mockTopologyService.getTopology(eq(mockConn), any(Boolean.class)))
-            .thenReturn(mockTopology);
+        .thenReturn(mockTopology);
     when(mockTopologyService.getHostByName(mockConn)).thenReturn(writerHost);
 
     final WriterFailoverHandler writerFailoverHandler = Mockito.mock(WriterFailoverHandler.class);
@@ -355,7 +355,7 @@ public class ClusterAwareConnectionProxyTest {
     final List<HostInfo> mockTopology = new ArrayList<>();
     mockTopology.add(writerHost);
     when(mockTopologyService.getTopology(eq(mockConn), any(Boolean.class)))
-            .thenReturn(mockTopology);
+        .thenReturn(mockTopology);
     when(mockTopologyService.getHostByName(mockConn)).thenReturn(writerHost);
 
     final WriterFailoverHandler writerFailoverHandler = Mockito.mock(WriterFailoverHandler.class);
@@ -443,7 +443,7 @@ public class ClusterAwareConnectionProxyTest {
     final List<HostInfo> mockTopology = new ArrayList<>();
     mockTopology.add(writerHost);
     when(mockTopologyService.getTopology(eq(mockConn), any(Boolean.class)))
-            .thenReturn(mockTopology);
+        .thenReturn(mockTopology);
     when(mockTopologyService.getHostByName(mockConn)).thenReturn(writerHost);
 
     final WriterFailoverHandler writerFailoverHandler = Mockito.mock(WriterFailoverHandler.class);
@@ -537,7 +537,7 @@ public class ClusterAwareConnectionProxyTest {
     final List<HostInfo> mockTopology = new ArrayList<>();
     mockTopology.add(writerHost);
     when(mockTopologyService.getTopology(eq(mockConn), any(Boolean.class)))
-            .thenReturn(mockTopology);
+        .thenReturn(mockTopology);
     when(mockTopologyService.getHostByName(mockConn)).thenReturn(writerHost);
 
     final WriterFailoverHandler writerFailoverHandler = Mockito.mock(WriterFailoverHandler.class);
@@ -580,7 +580,7 @@ public class ClusterAwareConnectionProxyTest {
     final List<HostInfo> mockTopology = new ArrayList<>();
     mockTopology.add(writerHost);
     when(mockTopologyService.getTopology(eq(mockConn), any(Boolean.class)))
-            .thenReturn(mockTopology);
+        .thenReturn(mockTopology);
     when(mockTopologyService.getHostByName(mockConn)).thenReturn(writerHost);
 
     final WriterFailoverHandler writerFailoverHandler = Mockito.mock(WriterFailoverHandler.class);
@@ -646,7 +646,7 @@ public class ClusterAwareConnectionProxyTest {
     final ConnectionUrl conStr = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
     final TopologyService mockTopologyService = Mockito.mock(TopologyService.class);
 
-    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host", "test");
+    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host", "test", "", "");
     final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test");
     final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host", "test");
     final List<HostInfo> topology = new ArrayList<>();
@@ -685,7 +685,7 @@ public class ClusterAwareConnectionProxyTest {
     final int connectionHostIndex = 1;
 
     final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host", "test");
-    final HostInfo readerAHost = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test");
+    final HostInfo readerAHost = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test", "", "");
     final List<HostInfo> topology = new ArrayList<>();
     topology.add(writerHost);
     topology.add(readerAHost);
@@ -723,7 +723,7 @@ public class ClusterAwareConnectionProxyTest {
     final int newConnectionHostIndex = 1;
 
     final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host", "test");
-    final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test");
+    final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test", "", "");
     final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host", "test");
     final List<HostInfo> topology = new ArrayList<>();
     topology.add(writerHost);
@@ -766,7 +766,7 @@ public class ClusterAwareConnectionProxyTest {
     final ConnectionUrl conStr = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
     final TopologyService mockTopologyService = Mockito.mock(TopologyService.class);
 
-    final HostInfo cachedWriterHost = ClusterAwareTestUtils.createBasicHostInfo("cached-writer-host", "test");
+    final HostInfo cachedWriterHost = ClusterAwareTestUtils.createBasicHostInfo("cached-writer-host", "test", "", "");
     final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test");
     final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host", "test");
     final List<HostInfo> cachedTopology = new ArrayList<>();
@@ -774,7 +774,7 @@ public class ClusterAwareConnectionProxyTest {
     cachedTopology.add(readerA_Host);
     cachedTopology.add(readerB_Host);
 
-    final HostInfo actualWriterHost = ClusterAwareTestUtils.createBasicHostInfo("actual-writer-host", "test");
+    final HostInfo actualWriterHost = ClusterAwareTestUtils.createBasicHostInfo("actual-writer-host", "test", "", "");
     final HostInfo obsoleteWriterHost = ClusterAwareTestUtils.createBasicHostInfo("obsolete-writer-host", "test");
     final List<HostInfo> actualTopology = new ArrayList<>();
     actualTopology.add(actualWriterHost);
@@ -823,7 +823,7 @@ public class ClusterAwareConnectionProxyTest {
     final ConnectionUrl conStr = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
     final TopologyService mockTopologyService = Mockito.mock(TopologyService.class);
 
-    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host", null);
+    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host", null, "", "");
     final HostInfo readerAHost = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", null);
     final HostInfo readerBHost = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host", null);
     final List<HostInfo> topology = new ArrayList<>();
@@ -866,7 +866,7 @@ public class ClusterAwareConnectionProxyTest {
     final ConnectionUrl conStr = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
     final TopologyService mockTopologyService = Mockito.mock(TopologyService.class);
 
-    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host", "test");
+    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host", "test", "", "");
     final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test");
     final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host", "test");
     final List<HostInfo> topology = new ArrayList<>();

--- a/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareTestUtils.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ca/ClusterAwareTestUtils.java
@@ -40,6 +40,10 @@ import java.util.Properties;
 
 public class ClusterAwareTestUtils {
     protected static HostInfo createBasicHostInfo(String instanceName, String db) {
+        return createBasicHostInfo(instanceName, db, null, null);
+    }
+
+    protected static HostInfo createBasicHostInfo(String instanceName, String db, String user, String password) {
         final Map<String, String> properties = new HashMap<>();
         properties.put(TopologyServicePropertyKeys.INSTANCE_NAME, instanceName);
         String url = "jdbc:mysql:aws://" + instanceName + ".com:1234/";
@@ -47,6 +51,6 @@ public class ClusterAwareTestUtils {
         properties.put(PropertyKey.DBNAME.getKeyName(), db);
         url += db;
         final ConnectionUrl conStr = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-        return new HostInfo(conStr, instanceName, 1234, null, null, properties);
+        return new HostInfo(conStr, instanceName, 1234, user, password, properties);
     }
 }

--- a/src/test/java/testsuite/integration/AwsIamAuthenticationIntegrationTest.java
+++ b/src/test/java/testsuite/integration/AwsIamAuthenticationIntegrationTest.java
@@ -149,6 +149,28 @@ public class AwsIamAuthenticationIntegrationTest {
         );
     }
 
+    /**
+     * Attempts a valid connection & caches the hosts, followed by invalid,
+     * then finally create another connection using the same properties as the first.
+     */
+    @Test
+    void test_8_ValidInvalidValidConnections() throws SQLException {
+        final Properties validProp = initProp(TEST_DB_USER, TEST_PASSWORD);
+        final Connection validConn = DriverManager.getConnection(DB_CONN_STR, validProp);
+        Assertions.assertNotNull(validConn);
+        validConn.close();
+
+        final Properties invalidProp = initProp("WRONG_" + TEST_DB_USER + "_USER", TEST_PASSWORD);
+        Assertions.assertThrows(
+            SQLException.class,
+            () -> DriverManager.getConnection(DB_CONN_STR, invalidProp)
+        );
+
+        final Connection validConn2 = DriverManager.getConnection(DB_CONN_STR, validProp);
+        Assertions.assertNotNull(validConn2);
+        validConn2.close();
+    }
+
     // Helper Functions
     private Properties initProp(final String user, final String password) {
         final Properties properties = new Properties();


### PR DESCRIPTION
### Summary

fix: Using an invalid connection after valid

### Description

Previously when connecting with an invalid connection after a valid connection would allow the user to connect despite having invalid information such as username.


### Additional Reviewers

@sergiyvamz 