### PR TITLE
Fix broken tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,6 +114,14 @@ tasks.shadowJar {
         into("META-INF/services/")
     }
 
+    doFirst {
+        mkdir("${buildDir}/META-INF/services/")
+        val driverFile = File("${buildDir}/META-INF/services/java.sql.Driver")
+        if (driverFile.createNewFile()) {
+            driverFile.writeText("software.aws.rds.jdbc.mysql.Driver")
+        }
+    }
+
     dependencies {
         exclude(dependency(":"))
     }

--- a/src/main/resources/META-INF/services/java.sql.Driver
+++ b/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,1 +1,0 @@
-software.aws.rds.jdbc.mysql.Driver


### PR DESCRIPTION
### Summary

Fix hanging test `testBug73053` and failing test `testBug69579`

### Description
#### testBug69579
The `META-INF/services/java.sql.Driver` file allows the `DriverManager` to locate and register a JDBC 4.0 driver. When this file is hard coded to the repository instead of manually generating this file, whenever `DriverManager.getConnection()` is called in the test, the AWS driver will also be registered. This interfered with `testBug69579`.

#### testBug73053
`testBug73053` hangs on Github Actions when it attempts to close the test connection, but passes locally. This is because the remote environment uses `TLSv1.3`.

When closing a connection, if `TLSv1.3` is used, the driver roughly follows this workflow: 
```
SSLSocketImpl#duplexCloseOutput -> SSLSocketImpl#bruteForceCloseInput(false) -> SSLSocketInputRecord#deplete
```
and it gets stuck in an infinite loop in `SSLSocketInputRecord#deplete`
```Java
while ((remaining = is.available()) != 0) {
    is.skip(remaining);
}
```
This method uses a stub `InputStream` implemented for `testBug73053`: `TestBug73053InputStreamWrapper`, where `is.available()` [will never return 0](https://github.com/awslabs/aws-mysql-jdbc/blob/ba9c5af7dbc68a83975f9cbba8376f65d515597a/src/test/java/testsuite/regression/ConnectionRegressionTest.java#L6799).
```Java
return available == 0 ? 1 : available;
```

The reasoning for this condition was due to this bug: https://bugs.mysql.com/bug.php?id=73053
> In some older Linux kernels the underlying system call may return 1 when actually no bytes are available in a CLOSE_WAIT state socket, even if EOF has been reached.

### Additional Reviewers

@hsuamz 
@sergiyvamz 
@ColinKYuen 