### PR TITLE
chore: Automate Maven Release

### DIFF
--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -1,0 +1,39 @@
+name: 'Release to Maven'
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  ubuntu-latest-aurora-release-to-maven:
+    name: 'Build And Release to Maven'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Clone Repository'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 50
+      - name: 'Set up JDK 8'
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: 'Build Driver'
+        run: |
+          ./gradlew --no-parallel --no-daemon -x test build
+      - name: "Decode Key Ring"
+        run: |
+          echo "${{secrets.GPG_SECRET_KEY_FILE}}" > ~/.gradle/secring.gpg.b64
+          base64 -d ~/.gradle/secring.gpg.b64 > ~/.gradle/secring.gpg
+      - name: 'Install GPG Secret Key'
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: 'Publish to Maven'
+        run: |
+          ./gradlew --no-parallel --no-daemon publishAllPublicationsToOSSRHRepository -Psigning.keyId=${{secrets.GPG_KEY_ID}} -Psigning.password=${{secrets.GPG_PASSPHRASE}} -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg)
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -1,0 +1,59 @@
+name: 'Release Draft'
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  actions: write
+  contents: write
+  deployments: write
+  packages: write
+  pull-requests: write
+  repository-projects: write
+
+jobs:
+  ubuntu-latest-aurora-release-gh-draft:
+    name: 'Build And Release Draft'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Clone Repository'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 50
+      - name: 'Set up JDK 8'
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: 'Build Driver'
+        run: |
+          ./gradlew --no-parallel --no-daemon -x test build
+      - name: 'Set Version Env Variable'
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: 'Get Release Details'
+        run: |
+          export RELEASE_DETAILS="$(awk -vN=2 'n<N;/^## /{++n}' CHANGELOG.md)"
+          export RELEASE_DETAILS="$(sed '${/^# /d;}' <<< "$RELEASE_DETAILS")"
+          export RELEASE_DETAILS="$(sed '$d' <<< "$RELEASE_DETAILS")"
+          touch RELEASE_DETAILS.md
+          echo "$RELEASE_DETAILS" > RELEASE_DETAILS.md
+      - name: 'Install GPG Secret Key'
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: 'Sign Jars'
+        run: |
+          export GPG_TTY=$(tty)
+          for jar in build/libs/*.jar; do gpg --detach-sign --armor $jar; done
+          for signed in build/libs/*.asc; do gpg --verify $signed; done
+      - name: 'Upload to Draft Release'
+        uses: ncipollo/release-action@v1
+        with:
+          draft: true
+          name: "AWS JDBC Driver for MySQL Public Preview - v${{ env.RELEASE_VERSION }}"
+          bodyFile: RELEASE_DETAILS.md
+          artifacts: build/libs/*
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,30 @@
 # Changelog
 
+## [Version 0.3.0 (Public Preview)](https://github.com/awslabs/aws-mysql-jdbc/releases/tag/0.3.0) - 2021-11-18
+
+### Added
+* AWS IAM Authentication is now supported. Usage instructions can be found [here](https://github.com/awslabs/aws-mysql-jdbc#aws-iam-database-authentication).
+
+### Improvements
+* Java 8 is now enforced in the build process.
+* Resolved an issue for when connecting with an invalid connection after a valid connection. Users were able to connect with cached information after a valid connection despite providing invalid information.
+* Bug fixes with flakey tests.
+
 ## [Version 0.2.0 (Public Preview)](https://github.com/awslabs/aws-mysql-jdbc/releases/tag/0.2.0) - 2021-08-30
 
 ### Added
-  * `setAwsProtocolOnly` changed to be static method.
-  * Merged upstream changes from MySQL 8.0.23 community driver.
+* Merged upstream changes from MySQL 8.0.23 community driver.
 
 ### Improvements
-  * Clarifications and improvements to README.md.
+* `setAwsProtocolOnly` changed to be static method.
+* Clarifications and improvements to README.md.
 
 ### Breaking Changes
-  * Potential Breaking Change: Loading of XML external entities are not loaded by default. Users must explictly allow it through using the new "allowXmlUnsafeExternalEntity" connection URL parameter. It is recommended that users verify external entities before loading them.
+* Potential Breaking Change: Loading of XML external entities are not loaded by default. Users must explictly allow it through using the new "allowXmlUnsafeExternalEntity" connection URL parameter. It is recommended that users verify external entities before loading them.
 
-## [Version 0.1.0 (Public Preview)](https://github.com/awslabs/aws-mysql-jdbc/releases/tag/0.2.0) - 2021-01-06
+## [Version 0.1.0 (Public Preview)](https://github.com/awslabs/aws-mysql-jdbc/releases/tag/0.1.0) - 2021-01-06
+
 Based on the MySQL 8.0.21 community driver.
 
 ### Features
-  * The driver is cluster aware for Amazon Aurora MySQL. It takes advantage of Amazon Aurora’s fast failover capabilities, reducing failover times from minutes to seconds.
+* The driver is cluster aware for Amazon Aurora MySQL. It takes advantage of Amazon Aurora's fast failover capabilities, reducing failover times from minutes to seconds.

--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ The default XML parser contained a security risk which made the driver prone to 
 
 ### AWS IAM Database Authentication
 
+**Note:** To preserve compatibility with customers using the community driver, IAM Authentication requires the [AWS Java SDK for Amazon RDS v1.x](https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds) to be included separately in the classpath. The AWS Java SDK for Amazon RDS is a runtime dependency and must be resolved.
+
 The driver supports Amazon AWS Identity and Access Management (IAM) authentication. When using AWS IAM database authentication, the host URL must be a valid Amazon endpoint, and not a custom domain or an IP address.
 <br>ie. `database-mysql-name.cluster-XYZ.us-east-2.rds.amazonaws.com`
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -319,7 +319,17 @@ publishing {
             }
         }
     }
+
     repositories {
+        maven {
+            name = "OSSRH"
+            url = uri("https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/")
+            credentials {
+                username = System.getenv("MAVEN_USERNAME")
+                password = System.getenv("MAVEN_PASSWORD")
+            }
+        }
+
         mavenLocal()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ spotbugs.version=4.0.0
 
 # Build properties
 com.mysql.cj.build.driver.version.major=0
-com.mysql.cj.build.driver.version.minor=2
+com.mysql.cj.build.driver.version.minor=3
 com.mysql.cj.build.driver.version.subminor=0
 com.mysql.cj.build.driver.displayName=Amazon Web Services (AWS) JDBC Driver for MySQL
 com.mysql.cj.build.driver.name=aws-mysql-connector-java


### PR DESCRIPTION
### Summary

Automate Maven Release

### Description

GitHub Actions `maven_release` automatically builds and signs drivers which are then uploaded to **Maven Staging**.
The following workflow runs whenever a **new release on GitHub is published.**
* Build Driver
* Set-up GPG to be used for signing
* Publishes signed files to Maven

Once published, it will be in the Staging Repository where you can manually **close** then later **release**.

The following secrets are required for new workflow
* `GPG_KEY_ID`, the public key ID (Last 8 characters)
* `MAVEN_USERNAME`, Login Username to Nexus Repository Manager
* `MAVEN_USERNAME`, Login Password to Nexus Repository Manager

Updated CHANGELOG.md, README.md, versioning to reflect changes.