### PR TITLE
fix: filter out methods that don't require failover

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ConnectionProxy.java
@@ -178,7 +178,7 @@ public class ConnectionProxy implements ICurrentConnectionProvider, InvocationHa
       throws Throwable {
     final String methodName = method.getName();
 
-    if (isDirectExecute(methodName, args)) {
+    if (isDirectExecute(methodName)) {
       return executeMethodDirectly(methodName, args);
     }
 
@@ -248,14 +248,14 @@ public class ConnectionProxy implements ICurrentConnectionProvider, InvocationHa
 
   /**
    * Special handling of method calls that can be handled without making an explicit invocation against the connection
-   * underlying this proxy. See {@link #isDirectExecute(String, Object[])}
+   * underlying this proxy. See {@link #isDirectExecute(String)}
    *
    * @param methodName The name of the method being called
    * @param args The argument parameters of the method that is being called
    * @return The results of the special method handling, according to which method was called
    */
   private Object executeMethodDirectly(String methodName, Object[] args) {
-    if (METHOD_EQUALS.equals(methodName)) {
+    if (METHOD_EQUALS.equals(methodName) && args != null && args.length > 0 && args[0] != null) {
       return args[0].equals(this);
     }
 
@@ -286,14 +286,10 @@ public class ConnectionProxy implements ICurrentConnectionProvider, InvocationHa
    * provided the arguments are valid when required (eg for METHOD_EQUALS and METHOD_ABORT)
    *
    * @param methodName The name of the method that is being called
-   * @param args The argument parameters of the method that is being called
    * @return true if we need to explicitly invoke the method indicated by methodName on the underlying connection
    */
-  private boolean isDirectExecute(String methodName, Object[] args) {
-
-    return (METHOD_EQUALS.equals(methodName)
-        || METHOD_HASH_CODE.equals(methodName)
-        && (args == null || args.length <= 0 || args[0] == null));
+  private boolean isDirectExecute(String methodName) {
+    return (METHOD_EQUALS.equals(methodName) || METHOD_HASH_CODE.equals(methodName));
   }
 
   /**
@@ -307,9 +303,9 @@ public class ConnectionProxy implements ICurrentConnectionProvider, InvocationHa
     }
 
     public synchronized Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-      if (METHOD_EQUALS.equals(method.getName())) {
-        // Let args[0] "unwrap" to its InvocationHandler if it is a proxy.
-        return args[0].equals(this);
+      final String methodName = method.getName();
+      if (isDirectExecute(methodName)) {
+        return executeMethodDirectly(methodName, args);
       }
 
       Object[] argsCopy = args == null ? null : Arrays.copyOf(args, args.length);
@@ -318,7 +314,7 @@ public class ConnectionProxy implements ICurrentConnectionProvider, InvocationHa
         Object result =
             ConnectionProxy.this.pluginManager.execute(
                 this.invokeOn.getClass(),
-                method.getName(),
+                methodName,
                 () -> method.invoke(this.invokeOn, args),
                 argsCopy);
         return proxyIfReturnTypeIsJdbcInterface(method.getReturnType(), result);


### PR DESCRIPTION
### Summary

fix: filter out methods that don't require failover
address issue reported in #206 

### Description

Execute `abort`, `close` and `isClosed` directly without the failover functionality.

### Additional Reviewers

@sergiyvamz 