### PR TITLE
Fix off by one error in performance histogram

### DIFF
--- a/src/main/core-impl/java/com/mysql/cj/log/BaseMetricsHolder.java
+++ b/src/main/core-impl/java/com/mysql/cj/log/BaseMetricsHolder.java
@@ -94,9 +94,9 @@ public class BaseMetricsHolder {
         if (histogramCounts == null) {
             createInitialHistogram(histogramBreakpoints, currentLowerBound, currentUpperBound);
         } else {
-            for (int i = 0; i < HISTOGRAM_BUCKETS; i++) {
+            for (int i = 1; i < HISTOGRAM_BUCKETS; i++) {
                 if (histogramBreakpoints[i] >= value) {
-                    histogramCounts[i] += numberOfTimes;
+                    histogramCounts[i - 1] += numberOfTimes;
 
                     break;
                 }


### PR DESCRIPTION
### Summary

<!--- General summary / title -->
Fix off by one error in performance histogram

### Description

<!--- Details of what you changed -->
There was an off by one error causing query times to be listed in the wrong category of the performance histogram.

### Additional Reviewers

<!-- Any additional reviewers -->