### PR TITLE
Add topology detection to the ReadWriteSplittingPlugin

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/RdsHostUtils.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/RdsHostUtils.java
@@ -226,8 +226,15 @@ public class RdsHostUtils {
     return explicitlySetProperties;
   }
 
+  public int getHostIndex(List<HostInfo> hostList, HostInfo host) {
+    if (host == null) {
+      return NO_CONNECTION_INDEX;
+    }
+    return getHostIndex(hostList, host.getHostPortPair());
+  }
+
   public int getHostIndex(List<HostInfo> hostList, String hostPortPair) {
-    if (Util.isNullOrEmpty(hostList)) {
+    if (Util.isNullOrEmpty(hostList) || StringUtils.isNullOrEmpty(hostPortPair)) {
       return NO_CONNECTION_INDEX;
     }
 
@@ -240,8 +247,19 @@ public class RdsHostUtils {
     return NO_CONNECTION_INDEX;
   }
 
-  public HostInfo getHostInfo(List<HostInfo> hosts, String hostPortPair) {
-    for (HostInfo host : hosts) {
+  public HostInfo getHostInfo(List<HostInfo> hostList, HostInfo host) {
+    if (host == null) {
+      return null;
+    }
+    return getHostInfo(hostList, host.getHostPortPair());
+  }
+
+  public HostInfo getHostInfo(List<HostInfo> hostList, String hostPortPair) {
+    if (Util.isNullOrEmpty(hostList) || StringUtils.isNullOrEmpty(hostPortPair)) {
+      return null;
+    }
+
+    for (HostInfo host : hostList) {
       if (host.getHostPortPair().equals(hostPortPair)) {
         return host;
       }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/RdsHostUtils.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/RdsHostUtils.java
@@ -227,7 +227,7 @@ public class RdsHostUtils {
   }
 
   public int getHostIndex(List<HostInfo> hostList, HostInfo host) {
-    if (host == null) {
+    if (Util.isNullOrEmpty(hostList) || host == null) {
       return NO_CONNECTION_INDEX;
     }
     return getHostIndex(hostList, host.getHostPortPair());
@@ -248,7 +248,7 @@ public class RdsHostUtils {
   }
 
   public HostInfo getHostInfo(List<HostInfo> hostList, HostInfo host) {
-    if (host == null) {
+    if (Util.isNullOrEmpty(hostList) || host == null) {
       return null;
     }
     return getHostInfo(hostList, host.getHostPortPair());
@@ -259,9 +259,9 @@ public class RdsHostUtils {
       return null;
     }
 
-    for (HostInfo host : hostList) {
-      if (host.getHostPortPair().equals(hostPortPair)) {
-        return host;
+    for (HostInfo potentialMatch : hostList) {
+      if (potentialMatch.getHostPortPair().equals(hostPortPair)) {
+        return potentialMatch;
       }
     }
     return null;

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/RdsHostUtils.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/RdsHostUtils.java
@@ -226,18 +226,27 @@ public class RdsHostUtils {
     return explicitlySetProperties;
   }
 
-  public int getHostIndex(List<HostInfo> hostList, HostInfo host) {
-    if (host == null || Util.isNullOrEmpty(hostList)) {
+  public int getHostIndex(List<HostInfo> hostList, String hostPortPair) {
+    if (Util.isNullOrEmpty(hostList)) {
       return NO_CONNECTION_INDEX;
     }
 
     for (int i = 0; i < hostList.size(); i++) {
       HostInfo potentialMatch = hostList.get(i);
-      if (potentialMatch != null && potentialMatch.equalHostPortPair(host)) {
+      if (hostPortPair.equals(potentialMatch.getHostPortPair())) {
         return i;
       }
     }
     return NO_CONNECTION_INDEX;
+  }
+
+  public HostInfo getHostInfo(List<HostInfo> hosts, String hostPortPair) {
+    for (HostInfo host : hosts) {
+      if (host.getHostPortPair().equals(hostPortPair)) {
+        return host;
+      }
+    }
+    return null;
   }
 
   private void logAndThrow(String msg) throws SQLException {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPlugin.java
@@ -220,7 +220,7 @@ public class ReadWriteSplittingPlugin implements IConnectionPlugin {
     final int currentHostIndex = this.rdsHostUtils.getHostIndex(this.hosts, currentHost.getHostPortPair());
     if (currentHostIndex == 0) {
       this.writerConnection = currentConnection;
-    } else if (currentHostIndex != -1) {
+    } else if (currentHostIndex != RdsHostUtils.NO_CONNECTION_INDEX) {
       this.readerConnection = currentConnection;
     }
   }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPlugin.java
@@ -175,7 +175,7 @@ public class ReadWriteSplittingPlugin implements IConnectionPlugin {
 
     if (MULTI_HOST_CONNECTION_AWS.equals(connectionUrl.getType())) {
       this.hosts.addAll(connectionUrl.getHostsList());
-      HostInfo currentHost = this.rdsHostUtils.getHostInfo(this.hosts, currentConnection.getHostPortPair());
+      final HostInfo currentHost = this.rdsHostUtils.getHostInfo(this.hosts, currentConnection.getHostPortPair());
       updateInternalConnections(currentConnection, currentHost);
       return;
     }
@@ -213,6 +213,10 @@ public class ReadWriteSplittingPlugin implements IConnectionPlugin {
   }
 
   private void updateInternalConnections(JdbcConnection currentConnection, HostInfo currentHost) {
+    if (currentHost == null) {
+      return;
+    }
+
     final int currentHostIndex = this.rdsHostUtils.getHostIndex(this.hosts, currentHost.getHostPortPair());
     if (currentHostIndex == 0) {
       this.writerConnection = currentConnection;

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPlugin.java
@@ -175,7 +175,7 @@ public class ReadWriteSplittingPlugin implements IConnectionPlugin {
 
     if (MULTI_HOST_CONNECTION_AWS.equals(connectionUrl.getType())) {
       this.hosts.addAll(connectionUrl.getHostsList());
-      final HostInfo currentHost = this.rdsHostUtils.getHostInfo(this.hosts, currentConnection.getHostPortPair());
+      final HostInfo currentHost = this.currentConnectionProvider.getCurrentHostInfo();
       updateInternalConnections(currentConnection, currentHost);
       return;
     }
@@ -213,11 +213,11 @@ public class ReadWriteSplittingPlugin implements IConnectionPlugin {
   }
 
   private void updateInternalConnections(JdbcConnection currentConnection, HostInfo currentHost) {
-    if (currentHost == null) {
+    if (currentConnection == null || currentHost == null) {
       return;
     }
 
-    final int currentHostIndex = this.rdsHostUtils.getHostIndex(this.hosts, currentHost.getHostPortPair());
+    final int currentHostIndex = this.rdsHostUtils.getHostIndex(this.hosts, currentHost);
     if (currentHostIndex == 0) {
       this.writerConnection = currentConnection;
     } else if (currentHostIndex != RdsHostUtils.NO_CONNECTION_INDEX) {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
@@ -321,7 +321,7 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
 
   private void validateConnection() throws SQLException {
     this.currentHostIndex = this.rdsHostUtils.getHostIndex(this.hosts,
-        topologyService.getHostByName(this.currentConnectionProvider.getCurrentConnection()));
+        topologyService.getHostByName(this.currentConnectionProvider.getCurrentConnection()).getHostPortPair());
     if (!isConnected()) {
       pickNewConnection();
       return;
@@ -381,7 +381,7 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
 
   private int getCandidateReaderForInitialConnection() {
     int lastUsedReaderIndex = this.rdsHostUtils.getHostIndex(this.hosts,
-        topologyService.getLastUsedReaderHost());
+        topologyService.getLastUsedReaderHost().getHostPortPair());
     if (lastUsedReaderIndex != NO_CONNECTION_INDEX) {
       metricsContainer.registerUseLastConnectedReader(true);
       return lastUsedReaderIndex;
@@ -858,7 +858,7 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
                 this.isClusterTopologyAvailable}));
     this.isMultiWriterCluster = this.topologyService.isMultiWriterCluster();
     this.currentHostIndex = this.rdsHostUtils.getHostIndex(this.hosts,
-        topologyService.getHostByName(this.currentConnectionProvider.getCurrentConnection()));
+        topologyService.getHostByName(this.currentConnectionProvider.getCurrentConnection()).getHostPortPair());
 
     if (this.isFailoverEnabled()) {
       logTopology();

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPluginTest.java
@@ -120,6 +120,7 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_trueFalse_threeHosts() throws SQLException {
+    when(mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(defaultWriterHost);
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn, mockWriterConn,
@@ -153,6 +154,7 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_falseInTransaction() throws SQLException {
+    when(mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(defaultWriterHost);
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn, mockWriterConn,
@@ -180,6 +182,7 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_trueTrue() throws SQLException {
+    when(mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(defaultWriterHost);
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn, mockWriterConn,
@@ -316,6 +319,7 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_true() throws SQLException {
+    when(mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(defaultWriterHost);
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn, mockWriterConn);
@@ -334,6 +338,7 @@ public class ReadWriteSplittingPluginTest {
   @Test
   public void testSetReadOnly_true_readerConnectionFailed() throws SQLException {
     when(mockConnectionProvider.connect(eq(defaultReaderHost))).thenThrow(SQLException.class);
+    when(mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(defaultWriterHost);
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn);
@@ -409,6 +414,7 @@ public class ReadWriteSplittingPluginTest {
   @Test
   public void testSetReadOnly_trueFalse_zeroHosts() throws SQLException {
     when(mockWriterConn.isClosed()).thenReturn(true);
+    when(mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(defaultWriterHost);
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn, mockWriterConn,
@@ -439,6 +445,7 @@ public class ReadWriteSplittingPluginTest {
   public void testSetReadOnly_false_writerConnectionFails() throws SQLException {
     when(mockConnectionProvider.connect(eq(defaultWriterHost))).thenThrow(SQLException.class);
     when(mockWriterConn.isClosed()).thenReturn(true);
+    when(mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(defaultWriterHost);
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn, mockWriterConn,
@@ -467,6 +474,7 @@ public class ReadWriteSplittingPluginTest {
   public void testSetReadOnly_true_readerConnectionFails_writerClosed() throws SQLException {
     when(mockConnectionProvider.connect(eq(defaultReaderHost))).thenThrow(SQLException.class);
     when(mockWriterConn.isClosed()).thenReturn(true);
+    when(mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(defaultWriterHost);
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn);

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPluginTest.java
@@ -28,10 +28,12 @@ package com.mysql.cj.jdbc.ha.plugins;
 
 import com.mysql.cj.conf.ConnectionUrl;
 import com.mysql.cj.conf.HostInfo;
+import com.mysql.cj.conf.PropertyKey;
 import com.mysql.cj.exceptions.MysqlErrorNumbers;
 import com.mysql.cj.jdbc.ConnectionImpl;
 import com.mysql.cj.jdbc.JdbcPropertySet;
 import com.mysql.cj.jdbc.JdbcPropertySetImpl;
+import com.mysql.cj.jdbc.ha.plugins.failover.ITopologyService;
 import com.mysql.cj.log.Log;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,14 +59,23 @@ import static org.mockito.Mockito.when;
 
 public class ReadWriteSplittingPluginTest {
   private static final int WRITER_INDEX = 0;
-  @Mock ICurrentConnectionProvider mockCurrentConnectionProvider;
-  @Mock IConnectionProvider mockConnectionProvider;
-  @Mock IConnectionPlugin mockNextPlugin;
-  @Mock ConnectionImpl mockWriterConn;
-  @Mock ConnectionImpl mockReaderConn;
-  @Mock Log mockLog;
-  @Mock ConnectionImpl mockClosedWriterConn;
-  @Mock ConnectionImpl mockNewWriterConn;
+  @Mock private ICurrentConnectionProvider mockCurrentConnectionProvider;
+  @Mock private ITopologyService mockTopologyService;
+  @Mock private IConnectionProvider mockConnectionProvider;
+  @Mock private IConnectionPlugin mockNextPlugin;
+  @Mock private ConnectionImpl mockWriterConn;
+  @Mock private ConnectionImpl mockReaderConn;
+  @Mock private Log mockLog;
+  @Mock private ConnectionImpl mockClosedWriterConn;
+  private final RdsHostUtils rdsHostUtils = new RdsHostUtils(mockLog); 
+  private static final String defaultUrl = "jdbc:mysql:aws://writer,reader1/test?" +
+      "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
+  private static final ConnectionUrl defaultConnUrl =
+      ConnectionUrl.getConnectionUrlInstance(defaultUrl, new Properties());
+  private static final List<HostInfo> defaultHosts = defaultConnUrl.getHostsList();
+  private static final HostInfo defaultWriterHost = defaultHosts.get(WRITER_INDEX);
+  private static final HostInfo defaultReaderHost = defaultHosts.get(WRITER_INDEX + 1);
+  private final JdbcPropertySet defaultProps = new JdbcPropertySetImpl();
   private AutoCloseable closeable;
 
   @AfterEach
@@ -73,53 +84,57 @@ public class ReadWriteSplittingPluginTest {
   }
 
   @BeforeEach
-  void init() {
+  void init() throws SQLException {
     closeable = MockitoAnnotations.openMocks(this);
+
+    mockDefaultConnectionBehavior(mockWriterConn, defaultWriterHost);
+    mockDefaultConnectionBehavior(mockReaderConn, defaultReaderHost);
+    mockClosedConnectionBehavior(mockClosedWriterConn);
+  }
+
+  void mockDefaultConnectionBehavior(ConnectionImpl mockConn, HostInfo mockConnHost) throws SQLException {
+    when(mockConn.getPropertySet()).thenReturn(defaultProps);
+    when(mockConn.getHostPortPair()).thenReturn(mockConnHost.getHostPortPair());
+    when(mockConn.isClosed()).thenReturn(false);
+    when(mockConnectionProvider.connect(eq(mockConnHost))).thenReturn(mockConn);
+  }
+
+  void mockClosedConnectionBehavior(ConnectionImpl mockConn) {
+    when(mockConn.getPropertySet()).thenReturn(defaultProps);
+    when(mockConn.isClosed()).thenReturn(true);
   }
 
   @Test
   public void testHostInfoStored() throws SQLException {
-    String url = "jdbc:mysql:aws://writer,reader1,reader2/test?" +
-        "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
-    ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-    JdbcPropertySet props = new JdbcPropertySetImpl();
+    when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(mockWriterConn);
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockCurrentConnectionProvider,
-        props,
+        defaultProps,
         mockNextPlugin,
         mockLog);
-    plugin.openInitialConnection(connUrl);
+    plugin.openInitialConnection(defaultConnUrl);
 
-    assertEquals(3, plugin.getHosts().size());
+    assertEquals(2, plugin.getHosts().size());
   }
 
   @Test
-  public void testSetReadOnly_trueFalse() throws SQLException {
-    String url = "jdbc:mysql:aws://writer,reader1,reader2/test?" +
-        "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
-    ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-    JdbcPropertySet props = new JdbcPropertySetImpl();
-
+  public void testSetReadOnly_trueFalse_threeHosts() throws SQLException {
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn, mockWriterConn,
         mockReaderConn, mockReaderConn, mockReaderConn);
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
-        mockCurrentConnectionProvider,
-        mockConnectionProvider,
-        props,
-        mockNextPlugin,
-        mockLog);
+
+    final String url = "jdbc:mysql:aws://writer,reader1,reader2/test?" +
+        "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
+    final ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
+    final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
     plugin.openInitialConnection(connUrl);
-    HostInfo writerHost = plugin.getHosts().get(WRITER_INDEX);
+    final HostInfo writerHost = plugin.getHosts().get(WRITER_INDEX);
 
     when(mockConnectionProvider.connect(not(eq(writerHost)))).thenReturn(mockReaderConn);
     when(mockConnectionProvider.connect(eq(writerHost))).thenReturn(mockWriterConn);
-    when(mockReaderConn.isClosed()).thenReturn(false);
-    when(mockWriterConn.getPropertySet()).thenReturn(props);
     when(mockReaderConn.getHostPortPair()).thenReturn("reader2:3306");
-    when(mockReaderConn.getPropertySet()).thenReturn(props);
 
     plugin.switchConnectionIfRequired(true);
     verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), not(eq(writerHost)));
@@ -138,42 +153,25 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_falseInTransaction() throws SQLException {
-    String url = "jdbc:mysql:aws://writer,reader1,reader2/test?" +
-        "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
-    ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-    JdbcPropertySet props = new JdbcPropertySetImpl();
-
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn, mockWriterConn,
         mockReaderConn, mockReaderConn, mockReaderConn);
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
-        mockCurrentConnectionProvider,
-        mockConnectionProvider,
-        props,
-        mockNextPlugin,
-        mockLog);
-    plugin.openInitialConnection(connUrl);
-    HostInfo writerHost = plugin.getHosts().get(WRITER_INDEX);
 
-    when(mockConnectionProvider.connect(not(eq(writerHost)))).thenReturn(mockReaderConn);
-    when(mockConnectionProvider.connect(eq(writerHost))).thenReturn(mockWriterConn);
-    when(mockReaderConn.isClosed()).thenReturn(false);
-    when(mockWriterConn.getPropertySet()).thenReturn(props);
-    when(mockReaderConn.getHostPortPair()).thenReturn("reader2:3306");
-    when(mockReaderConn.getPropertySet()).thenReturn(props);
+    final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
+    plugin.openInitialConnection(defaultConnUrl);
 
     plugin.switchConnectionIfRequired(true);
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), not(eq(writerHost)));
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), not(eq(defaultWriterHost)));
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(eq(mockWriterConn), any(HostInfo.class));
     assertEquals(mockReaderConn, plugin.getReaderConnection());
     assertEquals(mockWriterConn, plugin.getWriterConnection());
     assertTrue(plugin.getReadOnly());
 
     plugin.transactionBegun();
-    SQLException e = assertThrows(SQLException.class, () -> plugin.switchConnectionIfRequired(false));
+    final SQLException e = assertThrows(SQLException.class, () -> plugin.switchConnectionIfRequired(false));
     assertEquals(MysqlErrorNumbers.SQL_STATE_ACTIVE_SQL_TRANSACTION, e.getSQLState());
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), not(eq(writerHost)));
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), not(eq(defaultWriterHost)));
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(eq(mockWriterConn), any(HostInfo.class));
     assertEquals(mockReaderConn, plugin.getReaderConnection());
     assertEquals(mockWriterConn, plugin.getWriterConnection());
@@ -182,38 +180,23 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_trueTrue() throws SQLException {
-    String url = "jdbc:mysql:aws://writer,reader1,reader2/test?" +
-        "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
-    ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-    JdbcPropertySet props = new JdbcPropertySetImpl();
-
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn, mockWriterConn,
         mockReaderConn, mockReaderConn);
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
-        mockCurrentConnectionProvider,
-        mockConnectionProvider,
-        props,
-        mockNextPlugin,
-        mockLog);
-    plugin.openInitialConnection(connUrl);
-    HostInfo writerHost = plugin.getHosts().get(WRITER_INDEX);
 
-    when(mockConnectionProvider.connect(not(eq(writerHost)))).thenReturn(mockReaderConn);
-    when(mockReaderConn.isClosed()).thenReturn(false);
-    when(mockWriterConn.getPropertySet()).thenReturn(props);
-    when(mockReaderConn.getHostPortPair()).thenReturn("reader1:3306");
+    final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
+    plugin.openInitialConnection(defaultConnUrl);
 
     plugin.switchConnectionIfRequired(true);
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), not(eq(writerHost)));
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), not(eq(defaultWriterHost)));
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(eq(mockWriterConn), any(HostInfo.class));
     assertEquals(mockReaderConn, plugin.getReaderConnection());
     assertEquals(mockWriterConn, plugin.getWriterConnection());
     assertTrue(plugin.getReadOnly());
 
     plugin.switchConnectionIfRequired(true);
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), not(eq(writerHost)));
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), not(eq(defaultWriterHost)));
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(eq(mockWriterConn), any(HostInfo.class));
     assertEquals(mockReaderConn, plugin.getReaderConnection());
     assertEquals(mockWriterConn, plugin.getWriterConnection());
@@ -222,21 +205,12 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_false() throws SQLException {
-    String url = "jdbc:mysql:aws://writer,reader1,reader2/test?" +
-        "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
-    ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-    JdbcPropertySet props = new JdbcPropertySetImpl();
-
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn);
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
-        mockCurrentConnectionProvider,
-        mockConnectionProvider,
-        props,
-        mockNextPlugin,
-        mockLog);
-    plugin.openInitialConnection(connUrl);
+
+    final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
+    plugin.openInitialConnection(defaultConnUrl);
 
     plugin.switchConnectionIfRequired(false);
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(any(ConnectionImpl.class), any(HostInfo.class));
@@ -247,79 +221,66 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_true_zeroHosts() throws SQLException {
-    String url = "jdbc:mysql:aws:///test?" +
+    final String url = "jdbc:mysql:aws:///test?" +
         "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
-    ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-    JdbcPropertySet props = new JdbcPropertySetImpl();
+    final ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
 
+    when(mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(connUrl.getMainHost());
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn, mockWriterConn);
-    when(mockReaderConn.isClosed()).thenReturn(false);
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
-        mockCurrentConnectionProvider,
-        mockConnectionProvider,
-        props,
-        mockNextPlugin,
-        mockLog);
+    final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
     plugin.openInitialConnection(connUrl);
-    List<HostInfo> hosts = plugin.getHosts();
+    final List<HostInfo> hosts = plugin.getHosts();
     hosts.clear();
 
     plugin.switchConnectionIfRequired(true);
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(any(ConnectionImpl.class), any(HostInfo.class));
-    assertEquals(mockWriterConn, plugin.getWriterConnection());
+    assertNull(plugin.getWriterConnection());
     assertEquals(mockWriterConn, plugin.getReaderConnection());
     assertTrue(plugin.getReadOnly());
   }
 
   @Test
   public void testSetReadOnly_true_zeroHosts_writerClosed() throws SQLException {
-    String url = "jdbc:mysql:aws:///test?" +
+    final String url = "jdbc:mysql:aws:///test?" +
         "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
-    ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-    JdbcPropertySet props = new JdbcPropertySetImpl();
+    final ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
 
+    when(mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(connUrl.getMainHost());
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn, mockWriterConn);
     when(mockWriterConn.isClosed()).thenReturn(true);
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
-        mockCurrentConnectionProvider,
-        mockConnectionProvider,
-        props,
-        mockNextPlugin,
-        mockLog);
+    final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
     plugin.openInitialConnection(connUrl);
-    List<HostInfo> hosts = plugin.getHosts();
+    final List<HostInfo> hosts = plugin.getHosts();
     hosts.clear();
 
-    SQLException e = assertThrows(SQLException.class, () -> plugin.switchConnectionIfRequired(true));
+    final SQLException e = assertThrows(SQLException.class, () -> plugin.switchConnectionIfRequired(true));
     assertEquals(MysqlErrorNumbers.SQL_STATE_UNABLE_TO_CONNECT_TO_DATASOURCE, e.getSQLState());
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(any(ConnectionImpl.class), any(HostInfo.class));
-    assertEquals(mockWriterConn, plugin.getWriterConnection());
+    assertNull(plugin.getWriterConnection());
     assertNull(plugin.getReaderConnection());
     assertFalse(plugin.getReadOnly());
   }
 
   @Test
   public void testSetReadOnly_true_oneHost() throws SQLException {
-    String url = "jdbc:mysql:aws://writer/test?" +
+    final String url = "jdbc:mysql:aws://writer/test?" +
         "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
-    ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-    JdbcPropertySet props = new JdbcPropertySetImpl();
+    final ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
+    final HostInfo writerHost = connUrl.getMainHost();
 
+    when(mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(writerHost);
+    when(mockConnectionProvider.connect(writerHost)).thenReturn(mockWriterConn);
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn, mockWriterConn);
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
-        mockCurrentConnectionProvider,
-        mockConnectionProvider,
-        props,
-        mockNextPlugin,
-        mockLog);
+
+    final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
     plugin.openInitialConnection(connUrl);
 
     plugin.switchConnectionIfRequired(true);
@@ -331,62 +292,39 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_true_oneHost_writerClosed() throws SQLException {
-    String url = "jdbc:mysql:aws://writer/test?" +
+    final String url = "jdbc:mysql:aws://writer/test?" +
         "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
-    ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-    JdbcPropertySet props = new JdbcPropertySetImpl();
+    final ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
+    final HostInfo writerHost = connUrl.getMainHost();
 
+    when(mockConnectionProvider.connect(writerHost)).thenReturn(mockWriterConn);
+    when(mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(writerHost);
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockClosedWriterConn,
         mockClosedWriterConn, mockClosedWriterConn, mockClosedWriterConn);
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
-        mockCurrentConnectionProvider,
-        mockConnectionProvider,
-        props,
-        mockNextPlugin,
-        mockLog);
-    plugin.openInitialConnection(connUrl);
-    HostInfo writerHost = plugin.getHosts().get(WRITER_INDEX);
 
-    when(mockClosedWriterConn.isClosed()).thenReturn(true);
-    when(mockConnectionProvider.connect(writerHost)).thenReturn(mockNewWriterConn);
-    when(mockNewWriterConn.getHostPortPair()).thenReturn(writerHost.getHostPortPair());
-    when(mockClosedWriterConn.getPropertySet()).thenReturn(props);
+    final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
+    plugin.openInitialConnection(connUrl);
 
     plugin.switchConnectionIfRequired(true);
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockNewWriterConn), eq(writerHost));
-    verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(not(eq(mockNewWriterConn)), eq(writerHost));
-    assertEquals(mockNewWriterConn, plugin.getWriterConnection());
-    assertEquals(mockNewWriterConn, plugin.getReaderConnection());
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockWriterConn), eq(writerHost));
+    verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(not(eq(mockWriterConn)), eq(writerHost));
+    assertEquals(mockWriterConn, plugin.getWriterConnection());
+    assertEquals(mockWriterConn, plugin.getReaderConnection());
     assertTrue(plugin.getReadOnly());
   }
 
   @Test
-  public void testSetReadOnly_true_twoHosts() throws SQLException {
-    String url = "jdbc:mysql:aws://writer,reader1/test?" +
-        "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
-    ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-    JdbcPropertySet props = new JdbcPropertySetImpl();
-
+  public void testSetReadOnly_true() throws SQLException {
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn, mockWriterConn);
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
-        mockCurrentConnectionProvider,
-        mockConnectionProvider,
-        props,
-        mockNextPlugin,
-        mockLog);
-    plugin.openInitialConnection(connUrl);
-    HostInfo readerHost = plugin.getHosts().get(WRITER_INDEX + 1);
 
-    when(mockConnectionProvider.connect(eq(readerHost))).thenReturn(mockReaderConn);
-    when(mockReaderConn.isClosed()).thenReturn(false);
-    when(mockWriterConn.getPropertySet()).thenReturn(props);
-    when(mockReaderConn.getHostPortPair()).thenReturn("reader1:3306");
+    final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
+    plugin.openInitialConnection(defaultConnUrl);
 
     plugin.switchConnectionIfRequired(true);
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(readerHost));
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(defaultReaderHost));
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(eq(mockWriterConn), any(HostInfo.class));
     assertEquals(mockReaderConn, plugin.getReaderConnection());
     assertEquals(mockWriterConn, plugin.getWriterConnection());
@@ -395,25 +333,13 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_true_readerConnectionFailed() throws SQLException {
-    String url = "jdbc:mysql:aws://writer,reader1,reader2/test?" +
-        "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
-    ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-    JdbcPropertySet props = new JdbcPropertySetImpl();
-
+    when(mockConnectionProvider.connect(eq(defaultReaderHost))).thenThrow(SQLException.class);
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn);
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
-        mockCurrentConnectionProvider,
-        mockConnectionProvider,
-        props,
-        mockNextPlugin,
-        mockLog);
-    plugin.openInitialConnection(connUrl);
-    HostInfo writerHost = plugin.getHosts().get(WRITER_INDEX);
 
-    when(mockReaderConn.isClosed()).thenReturn(false);
-    when(mockConnectionProvider.connect(not(eq(writerHost)))).thenThrow(SQLException.class);
+    final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
+    plugin.openInitialConnection(defaultConnUrl);
 
     plugin.switchConnectionIfRequired(true);
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(any(ConnectionImpl.class), any(HostInfo.class));
@@ -424,45 +350,27 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_true_noReaderHostMatch() throws SQLException {
-    String url = "jdbc:mysql:aws://writer,reader1/test?" +
-        "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
-    ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-    JdbcPropertySet props = new JdbcPropertySetImpl();
-
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn, mockWriterConn,
         mockReaderConn, mockReaderConn, mockReaderConn,
         mockWriterConn, mockWriterConn, mockWriterConn);
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
-        mockCurrentConnectionProvider,
-        mockConnectionProvider,
-        props,
-        mockNextPlugin,
-        mockLog);
-    plugin.openInitialConnection(connUrl);
-    List<HostInfo> hosts = plugin.getHosts();
-    HostInfo writerHost = hosts.get(WRITER_INDEX);
-    HostInfo readerHost = hosts.get(WRITER_INDEX + 1);
 
-    when(mockConnectionProvider.connect(eq(readerHost))).thenReturn(mockReaderConn);
-    when(mockConnectionProvider.connect(eq(writerHost))).thenReturn(mockWriterConn);
-    when(mockReaderConn.isClosed()).thenReturn(false);
-    when(mockWriterConn.getPropertySet()).thenReturn(props);
-    when(mockReaderConn.getHostPortPair()).thenReturn("reader1:3306");
-    when(mockReaderConn.getPropertySet()).thenReturn(props);
+    final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
+    plugin.openInitialConnection(defaultConnUrl);
+    final List<HostInfo> hosts = plugin.getHosts();
 
     plugin.switchConnectionIfRequired(true);
     plugin.switchConnectionIfRequired(false);
     hosts.remove(WRITER_INDEX + 1);
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(readerHost));
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockWriterConn), eq(writerHost));
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(defaultReaderHost));
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockWriterConn), eq(defaultWriterHost));
     assertEquals(mockReaderConn, plugin.getReaderConnection());
     assertEquals(mockWriterConn, plugin.getWriterConnection());
 
     plugin.switchConnectionIfRequired(true);
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(readerHost));
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockWriterConn), eq(writerHost));
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(defaultReaderHost));
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockWriterConn), eq(defaultWriterHost));
     assertEquals(mockWriterConn, plugin.getReaderConnection());
     assertEquals(mockWriterConn, plugin.getWriterConnection());
     assertTrue(plugin.getReadOnly());
@@ -470,47 +378,29 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_true_noReaderHostMatch_writerClosed() throws SQLException {
-    String url = "jdbc:mysql:aws://writer,reader1/test?" +
-        "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
-    ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-    JdbcPropertySet props = new JdbcPropertySetImpl();
-
+    when(mockWriterConn.isClosed()).thenReturn(true);
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn, mockWriterConn,
         mockReaderConn, mockReaderConn, mockReaderConn,
         mockWriterConn, mockWriterConn, mockWriterConn);
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
-        mockCurrentConnectionProvider,
-        mockConnectionProvider,
-        props,
-        mockNextPlugin,
-        mockLog);
-    plugin.openInitialConnection(connUrl);
-    List<HostInfo> hosts = plugin.getHosts();
-    HostInfo writerHost = hosts.get(WRITER_INDEX);
-    HostInfo readerHost = hosts.get(WRITER_INDEX + 1);
 
-    when(mockConnectionProvider.connect(eq(readerHost))).thenReturn(mockReaderConn);
-    when(mockConnectionProvider.connect(eq(writerHost))).thenReturn(mockWriterConn);
-    when(mockReaderConn.isClosed()).thenReturn(false);
-    when(mockWriterConn.isClosed()).thenReturn(true);
-    when(mockWriterConn.getPropertySet()).thenReturn(props);
-    when(mockReaderConn.getHostPortPair()).thenReturn("reader1:3306");
-    when(mockReaderConn.getPropertySet()).thenReturn(props);
+    final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
+    plugin.openInitialConnection(defaultConnUrl);
+    final List<HostInfo> hosts = plugin.getHosts();
 
     plugin.switchConnectionIfRequired(true);
     plugin.switchConnectionIfRequired(false);
     hosts.remove(WRITER_INDEX + 1);
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(readerHost));
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockWriterConn), eq(writerHost));
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(defaultReaderHost));
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockWriterConn), eq(defaultWriterHost));
     assertEquals(mockReaderConn, plugin.getReaderConnection());
     assertEquals(mockWriterConn, plugin.getWriterConnection());
 
-    SQLException e = assertThrows(SQLException.class, () -> plugin.switchConnectionIfRequired(true));
+    final SQLException e = assertThrows(SQLException.class, () -> plugin.switchConnectionIfRequired(true));
     assertEquals(MysqlErrorNumbers.SQL_STATE_UNABLE_TO_CONNECT_TO_DATASOURCE, e.getSQLState());
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(readerHost));
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockWriterConn), eq(writerHost));
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(defaultReaderHost));
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockWriterConn), eq(defaultWriterHost));
     assertEquals(mockReaderConn, plugin.getReaderConnection());
     assertEquals(mockWriterConn, plugin.getWriterConnection());
     assertFalse(plugin.getReadOnly());
@@ -518,41 +408,27 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_trueFalse_zeroHosts() throws SQLException {
-    String url = "jdbc:mysql:aws://writer,reader1/test?" +
-        "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
-    ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-    JdbcPropertySet props = new JdbcPropertySetImpl();
-
+    when(mockWriterConn.isClosed()).thenReturn(true);
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn, mockWriterConn,
         mockReaderConn, mockReaderConn);
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
-        mockCurrentConnectionProvider,
-        mockConnectionProvider,
-        props,
-        mockNextPlugin,
-        mockLog);
-    plugin.openInitialConnection(connUrl);
-    List<HostInfo> hosts = plugin.getHosts();
-    HostInfo readerHost = hosts.get(WRITER_INDEX + 1);
 
-    when(mockConnectionProvider.connect(eq(readerHost))).thenReturn(mockReaderConn);
-    when(mockWriterConn.isClosed()).thenReturn(true);
-    when(mockReaderConn.getHostPortPair()).thenReturn("reader1:3306");
-    when(mockWriterConn.getPropertySet()).thenReturn(props);
+    final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
+    plugin.openInitialConnection(defaultConnUrl);
+    final List<HostInfo> hosts = plugin.getHosts();
 
     plugin.switchConnectionIfRequired(true);
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(readerHost));
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(defaultReaderHost));
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(eq(mockWriterConn), any(HostInfo.class));
     assertEquals(mockReaderConn, plugin.getReaderConnection());
     assertEquals(mockWriterConn, plugin.getWriterConnection());
     assertTrue(plugin.getReadOnly());
 
     hosts.clear();
-    SQLException e = assertThrows(SQLException.class, () -> plugin.switchConnectionIfRequired(false));
+    final SQLException e = assertThrows(SQLException.class, () -> plugin.switchConnectionIfRequired(false));
     assertEquals(MysqlErrorNumbers.SQL_STATE_UNABLE_TO_CONNECT_TO_DATASOURCE, e.getSQLState());
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(readerHost));
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(defaultReaderHost));
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(eq(mockWriterConn), any(HostInfo.class));
     assertEquals(mockReaderConn, plugin.getReaderConnection());
     assertEquals(mockWriterConn, plugin.getWriterConnection());
@@ -561,42 +437,26 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_false_writerConnectionFails() throws SQLException {
-    String url = "jdbc:mysql:aws://writer,reader1/test?" +
-        "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
-    ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-    JdbcPropertySet props = new JdbcPropertySetImpl();
-
+    when(mockConnectionProvider.connect(eq(defaultWriterHost))).thenThrow(SQLException.class);
+    when(mockWriterConn.isClosed()).thenReturn(true);
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn, mockWriterConn,
         mockReaderConn, mockReaderConn);
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
-        mockCurrentConnectionProvider,
-        mockConnectionProvider,
-        props,
-        mockNextPlugin,
-        mockLog);
-    plugin.openInitialConnection(connUrl);
-    List<HostInfo> hosts = plugin.getHosts();
-    HostInfo writerHost = hosts.get(WRITER_INDEX);
-    HostInfo readerHost = hosts.get(WRITER_INDEX + 1);
 
-    when(mockConnectionProvider.connect(eq(readerHost))).thenReturn(mockReaderConn);
-    when(mockConnectionProvider.connect(eq(writerHost))).thenThrow(SQLException.class);
-    when(mockWriterConn.isClosed()).thenReturn(true);
-    when(mockReaderConn.getHostPortPair()).thenReturn("reader1:3306");
-    when(mockWriterConn.getPropertySet()).thenReturn(props);
+    final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
+    plugin.openInitialConnection(defaultConnUrl);
 
     plugin.switchConnectionIfRequired(true);
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(readerHost));
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(defaultReaderHost));
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(eq(mockWriterConn), any(HostInfo.class));
     assertEquals(mockReaderConn, plugin.getReaderConnection());
     assertEquals(mockWriterConn, plugin.getWriterConnection());
     assertTrue(plugin.getReadOnly());
 
-    SQLException e = assertThrows(SQLException.class, () -> plugin.switchConnectionIfRequired(false));
+    final SQLException e = assertThrows(SQLException.class, () -> plugin.switchConnectionIfRequired(false));
     assertEquals(MysqlErrorNumbers.SQL_STATE_UNABLE_TO_CONNECT_TO_DATASOURCE, e.getSQLState());
-    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(readerHost));
+    verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(defaultReaderHost));
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(eq(mockWriterConn), any(HostInfo.class));
     assertEquals(mockReaderConn, plugin.getReaderConnection());
     assertEquals(mockWriterConn, plugin.getWriterConnection());
@@ -605,32 +465,78 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_true_readerConnectionFails_writerClosed() throws SQLException {
-    String url = "jdbc:mysql:aws://writer,reader1/test?" +
-        "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
-    ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
-    JdbcPropertySet props = new JdbcPropertySetImpl();
-
+    when(mockConnectionProvider.connect(eq(defaultReaderHost))).thenThrow(SQLException.class);
+    when(mockWriterConn.isClosed()).thenReturn(true);
     when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
         mockWriterConn,
         mockWriterConn, mockWriterConn);
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
-        mockCurrentConnectionProvider,
-        mockConnectionProvider,
-        props,
-        mockNextPlugin,
-        mockLog);
-    plugin.openInitialConnection(connUrl);
-    List<HostInfo> hosts = plugin.getHosts();
-    HostInfo readerHost = hosts.get(WRITER_INDEX + 1);
 
-    when(mockConnectionProvider.connect(eq(readerHost))).thenThrow(SQLException.class);
-    when(mockWriterConn.isClosed()).thenReturn(true);
+    final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
+    plugin.openInitialConnection(defaultConnUrl);
 
-    SQLException e = assertThrows(SQLException.class, () -> plugin.switchConnectionIfRequired(true));
+    final SQLException e = assertThrows(SQLException.class, () -> plugin.switchConnectionIfRequired(true));
     assertEquals(MysqlErrorNumbers.SQL_STATE_UNABLE_TO_CONNECT_TO_DATASOURCE, e.getSQLState());
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(any(ConnectionImpl.class), any(HostInfo.class));
     assertNull(plugin.getReaderConnection());
     assertEquals(mockWriterConn, plugin.getWriterConnection());
     assertFalse(plugin.getReadOnly());
+  }
+
+  @Test
+  public void testClusterSettings() throws SQLException {
+    final String url = "jdbc:mysql:aws://10.10.10.10/test?" +
+        "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
+    String clusterId = "test-cluster-id";
+    final Properties properties = new Properties();
+    properties.setProperty(PropertyKey.clusterInstanceHostPattern.getKeyName(), "?.my-custom-domain.com:3306");
+    properties.setProperty(PropertyKey.clusterId.getKeyName(), clusterId);
+    final ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, properties);
+    final JdbcPropertySet propertySet = new JdbcPropertySetImpl();
+    propertySet.initializeProperties(properties);
+
+    when(mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(defaultReaderHost);
+    when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(mockReaderConn);
+    when(mockTopologyService.getTopology(eq(mockReaderConn), eq(false))).thenReturn(defaultHosts);
+    when(mockTopologyService.getHostByName(eq(mockReaderConn))).thenReturn(defaultReaderHost);
+
+    final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(propertySet);
+    plugin.openInitialConnection(connUrl);
+
+    verify(mockTopologyService, times(1)).getTopology(eq(mockReaderConn), eq(false));
+    verify(mockTopologyService, times(1)).setClusterId(clusterId);
+    assertNull(plugin.getWriterConnection());
+    assertEquals(mockReaderConn, plugin.getReaderConnection());
+    assertFalse(plugin.getReadOnly());
+  }
+
+  @Test
+  public void testHostPatternRequired() throws SQLException {
+    final String url = "jdbc:mysql:aws://10.10.10.10/test?" +
+        "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
+    final ConnectionUrl connUrl = ConnectionUrl.getConnectionUrlInstance(url, new Properties());
+
+    when(mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(defaultWriterHost);
+    when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(mockWriterConn);
+    when(mockTopologyService.getTopology(eq(mockWriterConn), eq(false))).thenReturn(defaultHosts);
+    when(mockTopologyService.getHostByName(eq(mockWriterConn))).thenReturn(defaultWriterHost);
+
+    final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
+
+    assertThrows(SQLException.class, () -> plugin.openInitialConnection(connUrl));
+    verify(mockTopologyService, times(1)).getTopology(eq(mockWriterConn), eq(false));
+    assertNull(plugin.getWriterConnection());
+    assertNull(plugin.getReaderConnection());
+    assertFalse(plugin.getReadOnly());
+  }
+  
+  private ReadWriteSplittingPlugin initReadWriteSplittingPlugin(JdbcPropertySet props) {
+    return new ReadWriteSplittingPlugin(
+        mockCurrentConnectionProvider,
+        mockTopologyService,
+        mockConnectionProvider,
+        rdsHostUtils,
+        props,
+        mockNextPlugin,
+        mockLog);
   }
 }

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPluginTest.java
@@ -58,7 +58,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ReadWriteSplittingPluginTest {
-  private static final int WRITER_INDEX = 0;
   @Mock private ICurrentConnectionProvider mockCurrentConnectionProvider;
   @Mock private ITopologyService mockTopologyService;
   @Mock private IConnectionProvider mockConnectionProvider;
@@ -67,14 +66,16 @@ public class ReadWriteSplittingPluginTest {
   @Mock private ConnectionImpl mockReaderConn;
   @Mock private Log mockLog;
   @Mock private ConnectionImpl mockClosedWriterConn;
-  private final RdsHostUtils rdsHostUtils = new RdsHostUtils(mockLog); 
+
+  private static final int WRITER_INDEX = 0;
   private static final String defaultUrl = "jdbc:mysql:aws://writer,reader1/test?" +
       "connectionPluginFactories=com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory";
-  private static final ConnectionUrl defaultConnUrl =
+  private final RdsHostUtils rdsHostUtils = new RdsHostUtils(mockLog);
+  private final ConnectionUrl defaultConnUrl =
       ConnectionUrl.getConnectionUrlInstance(defaultUrl, new Properties());
-  private static final List<HostInfo> defaultHosts = defaultConnUrl.getHostsList();
-  private static final HostInfo defaultWriterHost = defaultHosts.get(WRITER_INDEX);
-  private static final HostInfo defaultReaderHost = defaultHosts.get(WRITER_INDEX + 1);
+  private final List<HostInfo> defaultHosts = defaultConnUrl.getHostsList();
+  private final HostInfo defaultWriterHost = defaultHosts.get(WRITER_INDEX);
+  private final HostInfo defaultReaderHost = defaultHosts.get(WRITER_INDEX + 1);
   private final JdbcPropertySet defaultProps = new JdbcPropertySetImpl();
   private AutoCloseable closeable;
 


### PR DESCRIPTION
### Summary

Add topology detection to the ReadWriteSplittingPlugin

### Description

- if a single host is supplied in the connection URL, attempt to query
Aurora to establish topology information
- if multiple hosts are supplied, simply use the supplied hosts for
topology information; the plugin will not query for topology

### Additional Reviewers

@sergiyv-bitquill 
@karenc-bq 