### PR TITLE
remove announcement user is using the AWS mysql driver

### DIFF
--- a/src/main/user-impl/java/software/aws/rds/jdbc/mysql/Driver.java
+++ b/src/main/user-impl/java/software/aws/rds/jdbc/mysql/Driver.java
@@ -58,7 +58,6 @@ public class Driver extends NonRegisteringDriver {
   static {
     try {
       DriverManager.registerDriver(new Driver());
-      System.out.println("You are using Amazon Web Services (AWS) JDBC Driver for MySQL.");
     } catch (SQLException E) {
       throw new RuntimeException("Can't register driver!");
     }


### PR DESCRIPTION
remove the announcement.

This is executed regardless of whether the user is connecting using the driver or not.