### PR TITLE
Add configuration option to load balance reader transactions

### DIFF
--- a/src/main/core-api/java/com/mysql/cj/conf/PropertyDefinitions.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/PropertyDefinitions.java
@@ -645,7 +645,7 @@ public class PropertyDefinitions {
                 new StringPropertyDefinition(PropertyKey.serverAffinityOrder, DEFAULT_VALUE_NULL_STRING, RUNTIME_NOT_MODIFIABLE,
                         Messages.getString("ConnectionProperties.serverAffinityOrder"), "8.0.8", CATEGORY_HA, Integer.MIN_VALUE),
 
-                // Cluster-aware failover settings
+                // Connection plugin settings
 
                 new StringPropertyDefinition(PropertyKey.clusterId, DEFAULT_VALUE_NULL_STRING, RUNTIME_NOT_MODIFIABLE,
                         Messages.getString("ConnectionProperties.clusterId"), "0.1.0", CATEGORY_HA, Integer.MIN_VALUE),
@@ -712,6 +712,9 @@ public class PropertyDefinitions {
 
                 new BooleanPropertyDefinition(PropertyKey.useAwsIam, DEFAULT_VALUE_FALSE, RUNTIME_NOT_MODIFIABLE,
                         Messages.getString("ConnectionProperties.useAwsIam"), "0.3.0", CATEGORY_SECURITY, Integer.MAX_VALUE),
+
+                new BooleanPropertyDefinition(PropertyKey.loadBalanceReadOnlyTraffic, DEFAULT_VALUE_FALSE, RUNTIME_NOT_MODIFIABLE,
+                        Messages.getString("ConnectionProperties.loadBalanceReadOnlyTraffic"), "1.2.0", CATEGORY_HA, Integer.MAX_VALUE),
 
                 //
                 // CATEGORY_PERFORMANCE

--- a/src/main/core-api/java/com/mysql/cj/conf/PropertyKey.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/PropertyKey.java
@@ -301,6 +301,9 @@ public enum PropertyKey {
     failureDetectionCount("failureDetectionCount", true),
     monitorDisposalTime("monitorDisposalTime", true),
 
+    // ReadWriteSplitting plugin
+    loadBalanceReadOnlyTraffic("loadBalanceReadOnlyTraffic", true),
+
     // XML enternal entity
     allowXmlUnsafeExternalEntity("allowXmlUnsafeExternalEntity", true),
 

--- a/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
+++ b/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
@@ -1051,7 +1051,7 @@ ConnectionProperties.failureDetectionInterval=Interval in millis between probes 
 ConnectionProperties.failureDetectionCount=Number of failed connection checks before considering database node unhealthy.
 ConnectionProperties.monitorDisposalTime=Interval in milliseconds for a monitor to be considered inactive and to be disposed.
 ConnectionProperties.useAwsIam=Set to true to use AWS IAM database authentication.
-ConnectionProperties.loadBalanceReadOnlyTraffic=Set to true to automatically load-balance reader queries when setReadOnly is set to true
+ConnectionProperties.loadBalanceReadOnlyTraffic=Set to true to automatically load-balance read-only transactions when setReadOnly is set to true
 
 AuroraTopologyService.1=[AuroraTopologyService] clusterId=''{0}''
 AuroraTopologyService.2=[AuroraTopologyService] clusterInstance host=''{0}'', port={1,number,#}, database=''{2}''

--- a/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
+++ b/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
@@ -1095,13 +1095,15 @@ ClusterAwareReaderFailoverHandler.3=[ClusterAwareReaderFailoverHandler] Trying t
 ClusterAwareReaderFailoverHandler.4=[ClusterAwareReaderFailoverHandler] Connected to reader [{0,number,#}] ''{1}''
 ClusterAwareReaderFailoverHandler.5=[ClusterAwareReaderFailoverHandler] Failed to connect to reader [{0,number,#}] ''{1}''
 
-ReadWriteSplittingPlugin.1=An error occurred while trying to switch to a reader connection
-ReadWriteSplittingPlugin.2=An error occurred while trying to switch to a writer connection
+ReadWriteSplittingPlugin.1=An error occurred while trying to switch to a reader connection.
+ReadWriteSplittingPlugin.2=An error occurred while trying to switch to a writer connection.
 ReadWriteSplittingPlugin.3=The driver was not able to retrieve any host information. Please ensure your connection string is correct.
-ReadWriteSplittingPlugin.5=The driver established a reader connection but could not find any matching host information
-ReadWriteSplittingPlugin.6=setReadOnly(false) was called on a read-only connection inside a transaction. Please complete the transaction before calling setReadOnly(false)
-ReadWriteSplittingPlugin.7=An error occurred while syncing session state during a read/write split
+ReadWriteSplittingPlugin.4=The driver attempted to switch to a reader connection but did not find a matching host entry for the reader connection in its host list.
+ReadWriteSplittingPlugin.5=The driver attempted to update its topology information but did not find a matching host entry for the current connection in its host list.
+ReadWriteSplittingPlugin.6=setReadOnly(false) was called on a read-only connection inside a transaction. Please complete the transaction before calling setReadOnly(false).
+ReadWriteSplittingPlugin.7=An error occurred while syncing session state during a read/write split.
 ReadWriteSplittingPlugin.8=The 'clusterInstanceHostPattern' configuration property is required when an IP address or custom domain is used to connect to a cluster that provides topology information. If you would instead like to connect without failover functionality, set the 'enableClusterAwareFailover' configuration property to false.
+ReadWriteSplittingPlugin.9=The driver attempted to update its internal connection information but did not find a matching host entry for the current connection in its host list.
 
 RdsHostUtils.1=Invalid value for the 'clusterInstanceHostPattern' configuration setting - the value could not be parsed
 RdsHostUtils.2=Invalid value for the 'clusterInstanceHostPattern' configuration setting - the host pattern must contain a '?' character as a placeholder for the DB instance identifiers of the instances in the cluster

--- a/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
+++ b/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
@@ -1051,6 +1051,7 @@ ConnectionProperties.failureDetectionInterval=Interval in millis between probes 
 ConnectionProperties.failureDetectionCount=Number of failed connection checks before considering database node unhealthy.
 ConnectionProperties.monitorDisposalTime=Interval in milliseconds for a monitor to be considered inactive and to be disposed.
 ConnectionProperties.useAwsIam=Set to true to use AWS IAM database authentication.
+ConnectionProperties.loadBalanceReadOnlyTraffic=Set to true to automatically load-balance reader queries when setReadOnly is set to true
 
 AuroraTopologyService.1=[AuroraTopologyService] clusterId=''{0}''
 AuroraTopologyService.2=[AuroraTopologyService] clusterInstance host=''{0}'', port={1,number,#}, database=''{2}''
@@ -1096,8 +1097,7 @@ ClusterAwareReaderFailoverHandler.5=[ClusterAwareReaderFailoverHandler] Failed t
 
 ReadWriteSplittingPlugin.1=An error occurred while trying to switch to a reader connection
 ReadWriteSplittingPlugin.2=An error occurred while trying to switch to a writer connection
-ReadWriteSplittingPlugin.3=The driver attempted to switch to a writer connection but did not have any host information
-ReadWriteSplittingPlugin.4=The driver attempted to switch to a reader connection but did not have any host information
+ReadWriteSplittingPlugin.3=The driver was not able to retrieve any host information. Please ensure your connection string is correct.
 ReadWriteSplittingPlugin.5=The driver established a reader connection but could not find any matching host information
 ReadWriteSplittingPlugin.6=setReadOnly(false) was called on a read-only connection inside a transaction. Please complete the transaction before calling setReadOnly(false)
 ReadWriteSplittingPlugin.7=An error occurred while syncing session state during a read/write split

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPlugin.java
@@ -151,7 +151,7 @@ public class ReadWriteSplittingPlugin implements IConnectionPlugin {
     }
 
     final boolean isAutoCommit = currentConnection.getAutoCommit();
-    if (isAutoCommit && "execute".equals(methodName) || "executeQuery".equals(methodName)) {
+    if (isAutoCommit && ("execute".equals(methodName) || "executeQuery".equals(methodName))) {
       return true;
     }
     return "commit".equals(methodName) || "rollback".equals(methodName);
@@ -459,6 +459,7 @@ public class ReadWriteSplittingPlugin implements IConnectionPlugin {
 
     if (!isConnectionUsable(this.readerConnection)) {
       initializeReaderConnection(currentConnection);
+      // The current connection may have changed; update it here in case it did.
       currentConnection = this.currentConnectionProvider.getCurrentConnection();
     }
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPlugin.java
@@ -156,7 +156,7 @@ public class ReadWriteSplittingPlugin implements IConnectionPlugin {
   }
 
   private boolean didMethodStartTransaction(String methodName, Object[] args) throws SQLException {
-    // If autocommit is off, any execute will start a transaction, unless the execute is itself closing the transaction
+    // If autocommit is off, any execute will start a transaction, unless the execute is closing the transaction using a SQL statement
     if (!this.currentConnectionProvider.getCurrentConnection().getAutoCommit()) {
       return isExecuteMethod(methodName) && !didMethodCloseTransactionUsingSqlStatement(methodName, args);
     }
@@ -183,9 +183,9 @@ public class ReadWriteSplittingPlugin implements IConnectionPlugin {
   }
 
   private boolean didMethodCloseTransaction(String methodName, Object[] args, boolean wasInTransactionBeforeExecution) throws SQLException {
-    // If autocommit is on, in most cases, any execute will start a transaction. The exceptions are:
-    // - We earlier started an implicit transaction via "START TRANSACTION" or "BEGIN"
-    // - The execute is itself starting a transaction via "START TRANSACTION" or "BEGIN"
+    // If autocommit is on, every execute will open and then close a transaction, except for the following cases:
+    // - We earlier started an implicit transaction using a SQL statement such as "START TRANSACTION" or "BEGIN"
+    // - The execute is starting a transaction using a SQL statement such as "START TRANSACTION" or "BEGIN"
     if (this.currentConnectionProvider.getCurrentConnection().getAutoCommit()
             && isExecuteMethod(methodName)
             && !wasInTransactionBeforeExecution

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPlugin.java
@@ -345,7 +345,9 @@ public class ReadWriteSplittingPlugin implements IConnectionPlugin {
       this.readerConnection = currentConnection;
     }
 
-    liveConnections.put(currentHost.getHostPortPair(), currentConnection);
+    if (!currentConnection.isClosed()) {
+      liveConnections.put(currentHost.getHostPortPair(), currentConnection);
+    }
   }
 
   @Override

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPlugin.java
@@ -123,10 +123,8 @@ public class ReadWriteSplittingPlugin implements IConnectionPlugin {
 
     if (METHOD_SET_READ_ONLY.equals(methodName) && args != null && args.length > 0) {
       switchConnectionIfRequired((Boolean) args[0]);
-//      this.isTransactionBoundary = false;
     } else if (this.explicitlyReadOnly && this.loadBalanceReadOnlyTraffic && isTransactionBoundary) {
       pickNewReaderConnection();
-//      this.isTransactionBoundary = false;
     }
 
     try {

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPluginTest.java
@@ -145,7 +145,7 @@ public class ReadWriteSplittingPluginTest {
   @Test
   public void testSetReadOnly_trueFalse_threeHosts() throws SQLException {
     when(mockCurrentConnectionProvider.getCurrentConnection())
-            .thenReturn(mockWriterConn, mockWriterConn, mockReaderConn);
+            .thenReturn(mockWriterConn, mockWriterConn, mockWriterConn, mockReaderConn);
 
     final ConnectionUrl connUrl = getConnectionUrl(3);
     mockConnectToReaderHosts(connUrl.getHostsList());
@@ -172,7 +172,7 @@ public class ReadWriteSplittingPluginTest {
   @Test
   public void testSetReadOnly_falseInTransaction() throws SQLException {
     when(mockCurrentConnectionProvider.getCurrentConnection())
-            .thenReturn(mockWriterConn, mockWriterConn, mockReaderConn);
+            .thenReturn(mockWriterConn, mockWriterConn, mockWriterConn, mockReaderConn);
 
     final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
     plugin.openInitialConnection(defaultConnUrl);
@@ -195,7 +195,7 @@ public class ReadWriteSplittingPluginTest {
   @Test
   public void testSetReadOnly_trueTrue() throws SQLException {
     when(mockCurrentConnectionProvider.getCurrentConnection())
-            .thenReturn(mockWriterConn, mockWriterConn, mockReaderConn);
+            .thenReturn(mockWriterConn, mockWriterConn, mockWriterConn, mockReaderConn);
 
     final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
     plugin.openInitialConnection(defaultConnUrl);
@@ -248,7 +248,8 @@ public class ReadWriteSplittingPluginTest {
 
     when(mockConnectionProvider.connect(writerHost)).thenReturn(mockWriterConn);
     when(mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(writerHost);
-    when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(mockClosedWriterConn);
+    when(mockCurrentConnectionProvider.getCurrentConnection()).thenReturn(
+            mockClosedWriterConn, mockClosedWriterConn, mockWriterConn);
 
     final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
     plugin.openInitialConnection(connUrl);
@@ -288,7 +289,7 @@ public class ReadWriteSplittingPluginTest {
   @Test
   public void testSetReadOnly_true_noReaderHostMatch() throws SQLException {
     when(mockCurrentConnectionProvider.getCurrentConnection())
-            .thenReturn(mockWriterConn, mockWriterConn, mockReaderConn, mockWriterConn);
+            .thenReturn(mockWriterConn, mockWriterConn, mockWriterConn, mockReaderConn, mockWriterConn);
 
     final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
     plugin.openInitialConnection(defaultConnUrl);
@@ -305,14 +306,14 @@ public class ReadWriteSplittingPluginTest {
     plugin.switchConnectionIfRequired(true);
     verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockReaderConn), eq(defaultReaderHost));
     verify(mockCurrentConnectionProvider, times(1)).setCurrentConnection(eq(mockWriterConn), eq(defaultWriterHost));
-    assertEquals(mockWriterConn, plugin.getReaderConnection());
+    assertEquals(mockReaderConn, plugin.getReaderConnection());
     assertEquals(mockWriterConn, plugin.getWriterConnection());
   }
 
   @Test
   public void testSetReadOnly_true_noReaderHostMatch_writerClosed() throws SQLException {
     when(mockCurrentConnectionProvider.getCurrentConnection())
-            .thenReturn(mockClosedWriterConn, mockClosedWriterConn, mockReaderConn, mockClosedWriterConn);
+            .thenReturn(mockClosedWriterConn, mockClosedWriterConn, mockClosedWriterConn, mockReaderConn, mockClosedWriterConn);
 
     final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
     plugin.openInitialConnection(defaultConnUrl);
@@ -338,7 +339,7 @@ public class ReadWriteSplittingPluginTest {
   public void testSetReadOnly_false_writerConnectionFails() throws SQLException {
     when(mockConnectionProvider.connect(eq(defaultWriterHost))).thenThrow(SQLException.class);
     when(mockCurrentConnectionProvider.getCurrentConnection())
-            .thenReturn(mockClosedWriterConn, mockClosedWriterConn, mockReaderConn);
+            .thenReturn(mockClosedWriterConn, mockClosedWriterConn, mockClosedWriterConn, mockReaderConn);
 
     final ReadWriteSplittingPlugin plugin = initReadWriteSplittingPlugin(defaultProps);
     plugin.openInitialConnection(defaultConnUrl);
@@ -478,7 +479,7 @@ public class ReadWriteSplittingPluginTest {
     final HostInfo writerHost = hosts.get(WRITER_INDEX);
 
     when(mockCurrentConnectionProvider.getCurrentConnection())
-            .thenReturn(mockWriterConn, mockWriterConn, mockReaderConn);
+            .thenReturn(mockWriterConn, mockWriterConn, mockWriterConn, mockReaderConn);
     when(mockTopologyService.getTopology(eq(mockWriterConn), eq(false))).thenReturn(hosts);
     when(this.mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(connUrl.getMainHost());
     when(mockReaderConn.getAutoCommit()).thenReturn(true);
@@ -517,7 +518,7 @@ public class ReadWriteSplittingPluginTest {
     final HostInfo writerHost = hosts.get(WRITER_INDEX);
 
     when(mockCurrentConnectionProvider.getCurrentConnection())
-            .thenReturn(mockWriterConn, mockWriterConn, mockReaderConn);
+            .thenReturn(mockWriterConn, mockWriterConn, mockWriterConn, mockReaderConn);
     when(mockTopologyService.getTopology(eq(mockWriterConn), eq(false))).thenReturn(hosts);
     when(this.mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(connUrl.getMainHost());
     when(mockReaderConn.getAutoCommit()).thenReturn(false);

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPluginTest.java
@@ -32,7 +32,6 @@ package com.mysql.cj.jdbc.ha.plugins;
 import com.mysql.cj.conf.ConnectionUrl;
 import com.mysql.cj.conf.HostInfo;
 import com.mysql.cj.conf.PropertyKey;
-import com.mysql.cj.conf.PropertySet;
 import com.mysql.cj.exceptions.MysqlErrorNumbers;
 import com.mysql.cj.jdbc.ConnectionImpl;
 import com.mysql.cj.jdbc.JdbcConnection;

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/ReadWriteSplittingPluginTest.java
@@ -481,7 +481,8 @@ public class ReadWriteSplittingPluginTest {
     when(mockCurrentConnectionProvider.getCurrentConnection())
             .thenReturn(mockWriterConn, mockWriterConn, mockWriterConn, mockReaderConn);
     when(mockTopologyService.getTopology(eq(mockWriterConn), eq(false))).thenReturn(hosts);
-    when(this.mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(connUrl.getMainHost());
+    when(mockTopologyService.getTopology(eq(mockReaderConn), eq(false))).thenReturn(hosts);
+    when(this.mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(connUrl.getMainHost(), hosts.get(1), hosts.get(1));
     when(mockReaderConn.getAutoCommit()).thenReturn(true);
     mockConnectToReaderHosts(hosts);
 
@@ -501,10 +502,18 @@ public class ReadWriteSplittingPluginTest {
     assertEquals(mockWriterConn, plugin.getWriterConnection());
 
     plugin.execute(Statement.class, "execute", mockCallable, new Object[] {});
-    verify(plugin, times(1)).pickNewReaderConnection();
+    verify(plugin, times(0)).pickNewReaderConnection();
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(eq(mockWriterConn), any(HostInfo.class));
 
     plugin.execute(Statement.class, "executeQuery", mockCallable, new Object[] {});
+    verify(plugin, times(1)).pickNewReaderConnection();
+    verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(eq(mockWriterConn), any(HostInfo.class));
+
+    plugin.execute(Statement.class, "getAutoCommit", mockCallable, new Object[] {});
+    verify(plugin, times(2)).pickNewReaderConnection();
+    verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(eq(mockWriterConn), any(HostInfo.class));
+
+    plugin.execute(Statement.class, "getAutoCommit", mockCallable, new Object[] {});
     verify(plugin, times(2)).pickNewReaderConnection();
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(eq(mockWriterConn), any(HostInfo.class));
   }
@@ -520,7 +529,8 @@ public class ReadWriteSplittingPluginTest {
     when(mockCurrentConnectionProvider.getCurrentConnection())
             .thenReturn(mockWriterConn, mockWriterConn, mockWriterConn, mockReaderConn);
     when(mockTopologyService.getTopology(eq(mockWriterConn), eq(false))).thenReturn(hosts);
-    when(this.mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(connUrl.getMainHost());
+    when(mockTopologyService.getTopology(eq(mockReaderConn), eq(false))).thenReturn(hosts);
+    when(this.mockCurrentConnectionProvider.getCurrentHostInfo()).thenReturn(connUrl.getMainHost(), hosts.get(1), hosts.get(1));
     when(mockReaderConn.getAutoCommit()).thenReturn(false);
     mockConnectToReaderHosts(hosts);
 
@@ -540,10 +550,18 @@ public class ReadWriteSplittingPluginTest {
     assertEquals(mockWriterConn, plugin.getWriterConnection());
 
     plugin.execute(JdbcConnection.class, "commit", mockCallable, new Object[] {});
-    verify(plugin, times(1)).pickNewReaderConnection();
+    verify(plugin, times(0)).pickNewReaderConnection();
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(eq(mockWriterConn), any(HostInfo.class));
 
     plugin.execute(JdbcConnection.class, "commit", mockCallable, new Object[] {});
+    verify(plugin, times(1)).pickNewReaderConnection();
+    verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(eq(mockWriterConn), any(HostInfo.class));
+
+    plugin.execute(Statement.class, "execute", mockCallable, new Object[] {});
+    verify(plugin, times(2)).pickNewReaderConnection();
+    verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(eq(mockWriterConn), any(HostInfo.class));
+
+    plugin.execute(Statement.class, "execute", mockCallable, new Object[] {});
     verify(plugin, times(2)).pickNewReaderConnection();
     verify(mockCurrentConnectionProvider, times(0)).setCurrentConnection(eq(mockWriterConn), any(HostInfo.class));
   }

--- a/src/test/java/testsuite/integration/container/aurora/AuroraMysqlIntegrationBaseTest.java
+++ b/src/test/java/testsuite/integration/container/aurora/AuroraMysqlIntegrationBaseTest.java
@@ -201,7 +201,7 @@ public abstract class AuroraMysqlIntegrationBaseTest {
     makeSureInstancesUp(instanceIDs);
   }
 
-  protected Properties initDefaultPropsNoTimeouts() {
+  protected static Properties initDefaultPropsNoTimeouts() {
     final Properties props = new Properties();
     props.setProperty(PropertyKey.USER.getKeyName(), TEST_USERNAME);
     props.setProperty(PropertyKey.PASSWORD.getKeyName(), TEST_PASSWORD);
@@ -213,7 +213,7 @@ public abstract class AuroraMysqlIntegrationBaseTest {
     return props;
   }
 
-  protected Properties initDefaultProps() {
+  protected static Properties initDefaultProps() {
     final Properties props = initDefaultPropsNoTimeouts();
     props.setProperty(PropertyKey.connectTimeout.getKeyName(), "3000");
     props.setProperty(PropertyKey.socketTimeout.getKeyName(), "3000");
@@ -221,7 +221,7 @@ public abstract class AuroraMysqlIntegrationBaseTest {
     return props;
   }
 
-  protected Properties initDefaultProxiedProps() {
+  protected static Properties initDefaultProxiedProps() {
     final Properties props = initDefaultProps();
     props.setProperty(PropertyKey.clusterInstanceHostPattern.getKeyName(), PROXIED_CLUSTER_TEMPLATE);
 

--- a/src/test/java/testsuite/integration/container/aurora/AuroraMysqlReadWriteSplittingTest.java
+++ b/src/test/java/testsuite/integration/container/aurora/AuroraMysqlReadWriteSplittingTest.java
@@ -574,7 +574,9 @@ public class AuroraMysqlReadWriteSplittingTest extends AuroraMysqlIntegrationBas
       assertNotEquals(writerConnectionId, previousReaderId);
       assertTrue(isDBInstanceReader(previousReaderId));
 
+      Statement stmt = conn.createStatement();
       for (int i = 0; i < 5; i++) {
+        stmt.executeQuery("SELECT " + i);
         conn.commit();
         String nextReaderId = queryInstanceId(conn);
         assertNotEquals(previousReaderId, nextReaderId);
@@ -583,6 +585,16 @@ public class AuroraMysqlReadWriteSplittingTest extends AuroraMysqlIntegrationBas
       }
 
       for (int i = 0; i < 5; i++) {
+        stmt.executeQuery("SELECT " + i);
+        stmt.execute("COMMIT");
+        String nextReaderId = queryInstanceId(conn);
+        assertNotEquals(previousReaderId, nextReaderId);
+        assertTrue(isDBInstanceReader(nextReaderId));
+        previousReaderId = nextReaderId;
+      }
+
+      for (int i = 0; i < 5; i++) {
+        stmt.executeQuery("SELECT " + i);
         conn.rollback();
         String nextReaderId = queryInstanceId(conn);
         assertNotEquals(previousReaderId, nextReaderId);
@@ -590,7 +602,15 @@ public class AuroraMysqlReadWriteSplittingTest extends AuroraMysqlIntegrationBas
         previousReaderId = nextReaderId;
       }
 
-      Statement stmt = conn.createStatement();
+      for (int i = 0; i < 5; i++) {
+        stmt.executeQuery("SELECT " + i);
+        stmt.execute("ROLLBACK");
+        String nextReaderId = queryInstanceId(conn);
+        assertNotEquals(previousReaderId, nextReaderId);
+        assertTrue(isDBInstanceReader(nextReaderId));
+        previousReaderId = nextReaderId;
+      }
+
       for (int i = 0; i < 5; i++) {
         stmt.executeQuery("SELECT " + i);
         conn.commit();

--- a/src/test/java/testsuite/integration/container/aurora/AuroraMysqlReadWriteSplittingTest.java
+++ b/src/test/java/testsuite/integration/container/aurora/AuroraMysqlReadWriteSplittingTest.java
@@ -685,42 +685,26 @@ public class AuroraMysqlReadWriteSplittingTest extends AuroraMysqlIntegrationBas
   }
 
   private static Properties getProps_allPlugins() {
-    Properties props = getDefaultProps();
+    Properties props = initDefaultProps();
     addAllPlugins(props);
     return props;
   }
 
   private static Properties getProxiedProps_allPlugins() {
-    Properties props = getDefaultProxiedProps();
+    Properties props = initDefaultProxiedProps();
     addAllPlugins(props);
     return props;
   }
 
   private static Properties getProps_readWritePlugin() {
-    Properties props = getDefaultProps();
+    Properties props = initDefaultProps();
     addReadWritePlugin(props);
     return props;
   }
 
   private static Properties getProxiedProps_readWritePlugin() {
-    Properties props = getDefaultProxiedProps();
+    Properties props = initDefaultProxiedProps();
     addReadWritePlugin(props);
-    return props;
-  }
-
-  private static Properties getDefaultProps() {
-    Properties props = new Properties();
-    props.setProperty(PropertyKey.USER.getKeyName(), TEST_USERNAME);
-    props.setProperty(PropertyKey.PASSWORD.getKeyName(), TEST_PASSWORD);
-    props.setProperty(PropertyKey.tcpKeepAlive.getKeyName(), Boolean.FALSE.toString());
-    props.setProperty(PropertyKey.connectTimeout.getKeyName(), "3000");
-    props.setProperty(PropertyKey.socketTimeout.getKeyName(), "3000");
-    return props;
-  }
-
-  private static Properties getDefaultProxiedProps() {
-    final Properties props = getDefaultProps();
-    props.setProperty(PropertyKey.clusterInstanceHostPattern.getKeyName(), PROXIED_CLUSTER_TEMPLATE);
     return props;
   }
 

--- a/src/test/java/testsuite/integration/container/aurora/AuroraMysqlReadWriteSplittingTest.java
+++ b/src/test/java/testsuite/integration/container/aurora/AuroraMysqlReadWriteSplittingTest.java
@@ -79,7 +79,7 @@ public class AuroraMysqlReadWriteSplittingTest extends AuroraMysqlIntegrationBas
   public void test_connectToWriter_setReadOnlyTrueFalseTrue(Properties props) throws SQLException {
     final String initialWriterId = instanceIDs[0];
 
-    try (final Connection conn = connectToInstance(initialWriterId + DB_CONN_STR_SUFFIX, MYSQL_PORT, props)) {
+    try (final Connection conn = connectToInstance(MYSQL_CLUSTER_URL, MYSQL_PORT, props)) {
       String writerConnectionId = queryInstanceId(conn);
       assertEquals(initialWriterId, writerConnectionId);
       assertTrue(isDBInstanceWriter(writerConnectionId));
@@ -127,7 +127,7 @@ public class AuroraMysqlReadWriteSplittingTest extends AuroraMysqlIntegrationBas
   public void test_setReadOnlyFalseInReadOnlyTransaction(Properties props) throws SQLException{
     final String initialWriterId = instanceIDs[0];
 
-    try (final Connection conn = connectToInstance(initialWriterId + DB_CONN_STR_SUFFIX, MYSQL_PORT, props)) {
+    try (final Connection conn = connectToInstance(MYSQL_CLUSTER_URL, MYSQL_PORT, props)) {
       String writerConnectionId = queryInstanceId(conn);
       assertEquals(initialWriterId, writerConnectionId);
       assertTrue(isDBInstanceWriter(writerConnectionId));
@@ -201,7 +201,7 @@ public class AuroraMysqlReadWriteSplittingTest extends AuroraMysqlIntegrationBas
   public void test_setReadOnlyFalseInTransaction_setAutocommitZero(Properties props) throws SQLException{
     final String initialWriterId = instanceIDs[0];
 
-    try (final Connection conn = connectToInstance(initialWriterId + DB_CONN_STR_SUFFIX, MYSQL_PORT, props)) {
+    try (final Connection conn = connectToInstance(MYSQL_CLUSTER_URL, MYSQL_PORT, props)) {
       String writerConnectionId = queryInstanceId(conn);
       assertEquals(initialWriterId, writerConnectionId);
       assertTrue(isDBInstanceWriter(writerConnectionId));
@@ -271,7 +271,7 @@ public class AuroraMysqlReadWriteSplittingTest extends AuroraMysqlIntegrationBas
     final String initialWriterId = instanceIDs[0];
 
     props.setProperty(PropertyKey.loadBalanceReadOnlyTraffic.getKeyName(), "true");
-    try (final Connection conn = connectToInstance(initialWriterId + DB_CONN_STR_SUFFIX, MYSQL_PORT, props)) {
+    try (final Connection conn = connectToInstance(MYSQL_CLUSTER_URL, MYSQL_PORT, props)) {
       String writerConnectionId = queryInstanceId(conn);
       assertEquals(initialWriterId, writerConnectionId);
       assertTrue(isDBInstanceWriter(writerConnectionId));
@@ -674,7 +674,7 @@ public class AuroraMysqlReadWriteSplittingTest extends AuroraMysqlIntegrationBas
       SQLException e = assertThrows(SQLException.class, conn::rollback);
       assertEquals(MysqlErrorNumbers.SQL_STATE_TRANSACTION_RESOLUTION_UNKNOWN, e.getSQLState());
 
-      try (final Connection newConn = connectToInstance(initialWriterId + DB_CONN_STR_SUFFIX, MYSQL_PORT, props)) {
+      try (final Connection newConn = connectToInstance(initialWriterId + DB_CONN_STR_SUFFIX + PROXIED_DOMAIN_NAME_SUFFIX, MYSQL_PROXY_PORT, props)) {
         newConn.setReadOnly(true);
         Statement newStmt = newConn.createStatement();
         ResultSet rs = newStmt.executeQuery("SELECT 1");

--- a/src/test/java/testsuite/integration/container/standard/StandardMysqlBaseTest.java
+++ b/src/test/java/testsuite/integration/container/standard/StandardMysqlBaseTest.java
@@ -125,7 +125,7 @@ public class StandardMysqlBaseTest {
     return rs.getString(1);
   }
 
-  protected Properties initDefaultProps() {
+  protected static Properties initDefaultProps() {
     final Properties props = initDefaultPropsNoTimeouts();
     props.setProperty(PropertyKey.connectTimeout.getKeyName(), "3000");
     props.setProperty(PropertyKey.socketTimeout.getKeyName(), "3000");
@@ -133,7 +133,7 @@ public class StandardMysqlBaseTest {
     return props;
   }
 
-  protected Properties initDefaultPropsNoTimeouts() {
+  protected static Properties initDefaultPropsNoTimeouts() {
     final Properties props = new Properties();
     props.setProperty(PropertyKey.USER.getKeyName(), TEST_USERNAME);
     props.setProperty(PropertyKey.PASSWORD.getKeyName(), TEST_PASSWORD);

--- a/src/test/java/testsuite/integration/container/standard/StandardMysqlReadWriteSplittingTest.java
+++ b/src/test/java/testsuite/integration/container/standard/StandardMysqlReadWriteSplittingTest.java
@@ -34,6 +34,9 @@ import com.mysql.cj.exceptions.MysqlErrorNumbers;
 import eu.rekawek.toxiproxy.Proxy;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -41,15 +44,23 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
 
-  @Test
-  public void test_connectToWriter_setReadOnlyTrueTrueFalseFalseTrue() throws SQLException {
-    try (final Connection conn = connect(getPropsWithReadWritePlugin())) {
+  private static Stream<Arguments> testParameters() {
+    return Stream.of(
+            Arguments.of(getProps_allPlugins()),
+            Arguments.of(getProps_readWritePlugin())
+    );
+  }
+
+  @ParameterizedTest(name = "test_connectToWriter_setReadOnlyTrueTrueFalseFalseTrue")
+  @MethodSource("testParameters")
+  public void test_connectToWriter_setReadOnlyTrueTrueFalseFalseTrue(Properties props) throws SQLException {
+    try (final Connection conn = connect(props)) {
       String writerConnectionId = queryInstanceId(conn);
 
       conn.setReadOnly(true);
@@ -74,9 +85,10 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
     }
   }
 
-  @Test
-  public void test_setReadOnlyFalseInReadOnlyTransaction() throws SQLException{
-    try (final Connection conn = connect(getPropsWithReadWritePlugin())) {
+  @ParameterizedTest(name = "test_setReadOnlyFalseInReadOnlyTransaction")
+  @MethodSource("testParameters")
+  public void test_setReadOnlyFalseInReadOnlyTransaction(Properties props) throws SQLException{
+    try (final Connection conn = connect(props)) {
       String writerConnectionId = queryInstanceId(conn);
 
       conn.setReadOnly(true);
@@ -100,9 +112,10 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
     }
   }
 
-  @Test
-  public void test_setReadOnlyFalseInTransaction_setAutocommitFalse() throws SQLException{
-    try (final Connection conn = connect(getPropsWithReadWritePlugin())) {
+  @ParameterizedTest(name = "test_setReadOnlyFalseInTransaction_setAutocommitFalse")
+  @MethodSource("testParameters")
+  public void test_setReadOnlyFalseInTransaction_setAutocommitFalse(Properties props) throws SQLException{
+    try (final Connection conn = connect(props)) {
       String writerConnectionId = queryInstanceId(conn);
 
       conn.setReadOnly(true);
@@ -126,9 +139,10 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
     }
   }
 
-  @Test
-  public void test_setReadOnlyFalseInTransaction_setAutocommitZero() throws SQLException{
-    try (final Connection conn = connect(getPropsWithReadWritePlugin())) {
+  @ParameterizedTest(name = "test_setReadOnlyFalseInTransaction_setAutocommitZero")
+  @MethodSource("testParameters")
+  public void test_setReadOnlyFalseInTransaction_setAutocommitZero(Properties props) throws SQLException{
+    try (final Connection conn = connect(props)) {
       String writerConnectionId = queryInstanceId(conn);
 
       conn.setReadOnly(true);
@@ -152,9 +166,10 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
     }
   }
 
-  @Test
-  public void test_setReadOnlyTrueInTransaction() throws SQLException{
-    try (final Connection conn = connect(getPropsWithReadWritePlugin())) {
+  @ParameterizedTest(name = "test_setReadOnlyTrueInTransaction")
+  @MethodSource("testParameters")
+  public void test_setReadOnlyTrueInTransaction(Properties props) throws SQLException{
+    try (final Connection conn = connect(props)) {
       String writerConnectionId = queryInstanceId(conn);
 
       final Statement stmt1 = conn.createStatement();
@@ -179,9 +194,10 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
     }
   }
 
-  @Test
-  public void test_setReadOnlyTrue_allReadersDown() throws SQLException, IOException {
-    try (Connection conn = connectWithProxy(getPropsWithReadWritePlugin())) {
+  @ParameterizedTest(name = "test_setReadOnlyTrue_allReadersDown")
+  @MethodSource("testParameters")
+  public void test_setReadOnlyTrue_allReadersDown(Properties props) throws SQLException, IOException {
+    try (Connection conn = connectWithProxy(props)) {
       String writerConnectionId = queryInstanceId(conn);
 
       // Kill all reader instances
@@ -214,9 +230,10 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
    * after this issue is fixed.
    */
   @Disabled
-  @Test
-  public void test_setReadOnlyTrue_allInstancesDown() throws SQLException, IOException {
-    try (Connection conn = connectWithProxy(getPropsWithReadWritePlugin())) {
+  @ParameterizedTest(name = "test_setReadOnlyTrue_allInstancesDown")
+  @MethodSource("testParameters")
+  public void test_setReadOnlyTrue_allInstancesDown(Properties props) throws SQLException, IOException {
+    try (Connection conn = connectWithProxy(props)) {
       // Kill all instances
       for (int i = 0; i < clusterSize; i++) {
         final String instanceId = instanceIDs[i];
@@ -234,9 +251,10 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
     }
   }
 
-  @Test
-  public void test_setReadOnlyTrue_allInstancesDown_writerClosed() throws SQLException, IOException {
-    try (Connection conn = connectWithProxy(getPropsWithReadWritePlugin())) {
+  @ParameterizedTest(name = "test_setReadOnlyTrue_allInstancesDown_writerClosed")
+  @MethodSource("testParameters")
+  public void test_setReadOnlyTrue_allInstancesDown_writerClosed(Properties props) throws SQLException, IOException {
+    try (Connection conn = connectWithProxy(props)) {
       conn.close();
 
       // Kill all instances
@@ -255,9 +273,10 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
     }
   }
 
-  @Test
-  public void test_setReadOnlyFalse_allInstancesDown() throws SQLException, IOException {
-    try (Connection conn = connectWithProxy(getPropsWithReadWritePlugin())) {
+  @ParameterizedTest(name = "test_setReadOnlyFalse_allInstancesDown")
+  @MethodSource("testParameters")
+  public void test_setReadOnlyFalse_allInstancesDown(Properties props) throws SQLException, IOException {
+    try (Connection conn = connectWithProxy(props)) {
       String writerConnectionId = queryInstanceId(conn);
 
       conn.setReadOnly(true);
@@ -280,9 +299,9 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
     }
   }
 
-  @Test
-  public void test_readerLoadBalancing_autocommitTrue() throws SQLException {
-    Properties props = getPropsWithReadWritePlugin();
+  @ParameterizedTest(name = "test_readerLoadBalancing_autocommitTrue")
+  @MethodSource("testParameters")
+  public void test_readerLoadBalancing_autocommitTrue(Properties props) throws SQLException {
     props.setProperty(PropertyKey.loadBalanceReadOnlyTraffic.getKeyName(), "true");
     try (final Connection conn = connect(props)) {
       String writerConnectionId = queryInstanceId(conn);
@@ -304,9 +323,9 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
     }
   }
 
-  @Test
-  public void test_readerLoadBalancing_autocommitFalse() throws SQLException {
-    Properties props = getPropsWithReadWritePlugin();
+  @ParameterizedTest(name = "test_readerLoadBalancing_autocommitFalse")
+  @MethodSource("testParameters")
+  public void test_readerLoadBalancing_autocommitFalse(Properties props) throws SQLException {
     props.setProperty(PropertyKey.loadBalanceReadOnlyTraffic.getKeyName(), "true");
     try (final Connection conn = connect(props)) {
       String writerConnectionId = queryInstanceId(conn);
@@ -336,12 +355,66 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
     }
   }
 
-  private Properties getPropsWithReadWritePlugin() {
-    Properties props = initDefaultProps();
+  @Test
+  public void test_transactionResolutionUnknown_readWriteSplittingPluginOnly() throws SQLException, IOException {
+    final String initialWriterId = instanceIDs[0];
+
+    Properties props = getProps_readWritePlugin();
+    props.setProperty(PropertyKey.loadBalanceReadOnlyTraffic.getKeyName(), "true");
+    try (final Connection conn = connectWithProxy(props)) {
+      String writerConnectionId = queryInstanceId(conn);
+      assertEquals(initialWriterId, writerConnectionId);
+
+      conn.setReadOnly(true);
+      conn.setAutoCommit(false);
+      String readerId = queryInstanceId(conn);
+      assertNotEquals(writerConnectionId, readerId);
+
+      final Statement stmt = conn.createStatement();
+      stmt.executeQuery("SELECT 1");
+      final Proxy proxyInstance = proxyMap.get(readerId);
+      if (proxyInstance != null) {
+        containerHelper.disableConnectivity(proxyInstance);
+      } else {
+        fail(String.format("%s does not have a proxy setup.", readerId));
+      }
+
+      SQLException e = assertThrows(SQLException.class, conn::rollback);
+      assertEquals(MysqlErrorNumbers.SQL_STATE_TRANSACTION_RESOLUTION_UNKNOWN, e.getSQLState());
+
+      try (final Connection newConn = connectWithProxy(props)) {
+        newConn.setReadOnly(true);
+        Statement newStmt = newConn.createStatement();
+        ResultSet rs = newStmt.executeQuery("SELECT 1");
+        rs.next();
+        assertEquals(1, rs.getInt(1));
+      }
+    }
+  }
+
+  private static Properties getProps_allPlugins() {
+    Properties props = getDefaultProps();
     props.setProperty(PropertyKey.connectionPluginFactories.getKeyName(),
             "com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory," +
                     "com.mysql.cj.jdbc.ha.plugins.failover.FailoverConnectionPluginFactory," +
                     "com.mysql.cj.jdbc.ha.plugins.NodeMonitoringConnectionPluginFactory");
+    return props;
+  }
+
+  private static Properties getProps_readWritePlugin() {
+    Properties props = getDefaultProps();
+    props.setProperty(PropertyKey.connectionPluginFactories.getKeyName(),
+            "com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory");
+    return props;
+  }
+
+  private static Properties getDefaultProps() {
+    Properties props = new Properties();
+    props.setProperty(PropertyKey.USER.getKeyName(), TEST_USERNAME);
+    props.setProperty(PropertyKey.PASSWORD.getKeyName(), TEST_PASSWORD);
+    props.setProperty(PropertyKey.tcpKeepAlive.getKeyName(), Boolean.FALSE.toString());
+    props.setProperty(PropertyKey.connectTimeout.getKeyName(), "3000");
+    props.setProperty(PropertyKey.socketTimeout.getKeyName(), "3000");
     return props;
   }
 }

--- a/src/test/java/testsuite/integration/container/standard/StandardMysqlReadWriteSplittingTest.java
+++ b/src/test/java/testsuite/integration/container/standard/StandardMysqlReadWriteSplittingTest.java
@@ -357,13 +357,10 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
 
   @Test
   public void test_transactionResolutionUnknown_readWriteSplittingPluginOnly() throws SQLException, IOException {
-    final String initialWriterId = instanceIDs[0];
-
     Properties props = getProps_readWritePlugin();
     props.setProperty(PropertyKey.loadBalanceReadOnlyTraffic.getKeyName(), "true");
     try (final Connection conn = connectWithProxy(props)) {
       String writerConnectionId = queryInstanceId(conn);
-      assertEquals(initialWriterId, writerConnectionId);
 
       conn.setReadOnly(true);
       conn.setAutoCommit(false);
@@ -372,7 +369,7 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
 
       final Statement stmt = conn.createStatement();
       stmt.executeQuery("SELECT 1");
-      final Proxy proxyInstance = proxyMap.get(readerId);
+      final Proxy proxyInstance = proxyMap.get(instanceIDs[1]);
       if (proxyInstance != null) {
         containerHelper.disableConnectivity(proxyInstance);
       } else {
@@ -393,7 +390,7 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
   }
 
   private static Properties getProps_allPlugins() {
-    Properties props = getDefaultProps();
+    Properties props = initDefaultProps();
     props.setProperty(PropertyKey.connectionPluginFactories.getKeyName(),
             "com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory," +
                     "com.mysql.cj.jdbc.ha.plugins.failover.FailoverConnectionPluginFactory," +
@@ -402,19 +399,9 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
   }
 
   private static Properties getProps_readWritePlugin() {
-    Properties props = getDefaultProps();
+    Properties props = initDefaultProps();
     props.setProperty(PropertyKey.connectionPluginFactories.getKeyName(),
             "com.mysql.cj.jdbc.ha.plugins.ReadWriteSplittingPluginFactory");
-    return props;
-  }
-
-  private static Properties getDefaultProps() {
-    Properties props = new Properties();
-    props.setProperty(PropertyKey.USER.getKeyName(), TEST_USERNAME);
-    props.setProperty(PropertyKey.PASSWORD.getKeyName(), TEST_PASSWORD);
-    props.setProperty(PropertyKey.tcpKeepAlive.getKeyName(), Boolean.FALSE.toString());
-    props.setProperty(PropertyKey.connectTimeout.getKeyName(), "3000");
-    props.setProperty(PropertyKey.socketTimeout.getKeyName(), "3000");
     return props;
   }
 }

--- a/src/test/java/testsuite/integration/container/standard/StandardMysqlReadWriteSplittingTest.java
+++ b/src/test/java/testsuite/integration/container/standard/StandardMysqlReadWriteSplittingTest.java
@@ -139,6 +139,7 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
     }
   }
 
+  @Disabled("Failing because getAutocommit does not return the correct value after executing 'SET autocommit = 0'")
   @ParameterizedTest(name = "test_setReadOnlyFalseInTransaction_setAutocommitZero")
   @MethodSource("testParameters")
   public void test_setReadOnlyFalseInTransaction_setAutocommitZero(Properties props) throws SQLException{
@@ -166,6 +167,7 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
     }
   }
 
+  @Disabled("Failing because getAutocommit does not return the correct value after executing 'SET autocommit = 0'")
   @ParameterizedTest(name = "test_setReadOnlyTrueInTransaction")
   @MethodSource("testParameters")
   public void test_setReadOnlyTrueInTransaction(Properties props) throws SQLException{

--- a/src/test/java/testsuite/integration/container/standard/StandardMysqlReadWriteSplittingTest.java
+++ b/src/test/java/testsuite/integration/container/standard/StandardMysqlReadWriteSplittingTest.java
@@ -320,14 +320,13 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
 
       for (int i = 0; i < 5; i++) {
         stmt.executeQuery("SELECT " + i);
-        stmt.executeQuery("SELECT " + (i + 1));
         conn.commit();
         readerConnectionId = queryInstanceId(conn);
         assertNotEquals(writerConnectionId, readerConnectionId);
 
         ResultSet rs = stmt.getResultSet();
         rs.next();
-        assertEquals(i + 1, rs.getInt(1));
+        assertEquals(i, rs.getInt(1));
 
         stmt.executeQuery("SELECT " + i);
         conn.rollback();


### PR DESCRIPTION
### Summary

Add configuration option to load balance reader transactions

### Description

- If reader load balancing is enabled and setReadOnly(true) has been called, the ReadWriteSplittingPlugin will switch reader connections at transaction boundaries
- Load balancing is performed by randomly selecting new reader hosts
- Also added a connection cache in the ReadWriteSplittingPlugin to avoid performance penalty for regular reader switching

### Additional Reviewers

@karenc-bq 
@sergiyv-bitquill 
@sergiyvamz 