### PR TITLE
Fix bug where failoverTimeoutMs was not obeyed

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareWriterFailoverHandler.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareWriterFailoverHandler.java
@@ -142,14 +142,21 @@ public class ClusterAwareWriterFailoverHandler implements IWriterFailoverHandler
     submitTasks(currentTopology, executorService, completionService);
 
     try {
-      WriterFailoverResult result = getNextResult(executorService, completionService);
+      long startTimeMs = System.currentTimeMillis();
+      WriterFailoverResult result = getNextResult(executorService, completionService, this.maxFailoverTimeoutMs);
       if (result.isConnected() || result.getException() != null) {
         return result;
       }
 
-      result = getNextResult(executorService, completionService);
-      if (result.isConnected() || result.getException() != null) {
-        return result;
+      long endTimeMs = System.currentTimeMillis();
+      int duration = (int)(endTimeMs - startTimeMs);
+      int remainingTime = this.maxFailoverTimeoutMs - duration;
+
+      if (remainingTime > 0) {
+        result = getNextResult(executorService, completionService, remainingTime);
+        if (result.isConnected() || result.getException() != null) {
+          return result;
+        }
       }
 
       this.log.logDebug(Messages.getString("ClusterAwareWriterFailoverHandler.3"));
@@ -178,10 +185,11 @@ public class ClusterAwareWriterFailoverHandler implements IWriterFailoverHandler
 
   private WriterFailoverResult getNextResult(
       ExecutorService executorService,
-      CompletionService<WriterFailoverResult> completionService) throws SQLException {
+      CompletionService<WriterFailoverResult> completionService,
+      int timeoutMs) throws SQLException {
     try {
       Future<WriterFailoverResult> firstCompleted = completionService.poll(
-          this.maxFailoverTimeoutMs, TimeUnit.MILLISECONDS);
+          timeoutMs, TimeUnit.MILLISECONDS);
       if (firstCompleted == null) {
         // The task was unsuccessful and we have timed out
         return new WriterFailoverResult(false, false, new ArrayList<>(), null, "None");

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareWriterFailoverHandler.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareWriterFailoverHandler.java
@@ -142,13 +142,13 @@ public class ClusterAwareWriterFailoverHandler implements IWriterFailoverHandler
     submitTasks(currentTopology, executorService, completionService);
 
     try {
-      long startTimeMs = System.currentTimeMillis();
+      long startTimeMs = System.nanoTime();
       WriterFailoverResult result = getNextResult(executorService, completionService, this.maxFailoverTimeoutMs);
       if (result.isConnected() || result.getException() != null) {
         return result;
       }
 
-      long endTimeMs = System.currentTimeMillis();
+      long endTimeMs = System.nanoTime();
       int duration = (int)(endTimeMs - startTimeMs);
       int remainingTime = this.maxFailoverTimeoutMs - duration;
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareWriterFailoverHandler.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareWriterFailoverHandler.java
@@ -142,18 +142,18 @@ public class ClusterAwareWriterFailoverHandler implements IWriterFailoverHandler
     submitTasks(currentTopology, executorService, completionService);
 
     try {
-      long startTimeMs = System.nanoTime();
+      long startTimeNano = System.nanoTime();
       WriterFailoverResult result = getNextResult(executorService, completionService, this.maxFailoverTimeoutMs);
       if (result.isConnected() || result.getException() != null) {
         return result;
       }
 
-      long endTimeMs = System.nanoTime();
-      int duration = (int)(endTimeMs - startTimeMs);
-      int remainingTime = this.maxFailoverTimeoutMs - duration;
+      long endTimeNano = System.nanoTime();
+      int durationMs = (int) TimeUnit.NANOSECONDS.toMillis(endTimeNano - startTimeNano);
+      int remainingTimeMs = this.maxFailoverTimeoutMs - durationMs;
 
-      if (remainingTime > 0) {
-        result = getNextResult(executorService, completionService, remainingTime);
+      if (remainingTimeMs > 0) {
+        result = getNextResult(executorService, completionService, remainingTimeMs);
         if (result.isConnected() || result.getException() != null) {
           return result;
         }


### PR DESCRIPTION
### Summary

Fix bug where failoverTimeoutMs was not obeyed

### Description

- Before this commit, failover could take up to two times the length of
  failoverTimeoutMs before giving up. This commit adds changes to
  limit failover to run for a maximum of failoverTimeoutMs
  milliseconds

### Additional Reviewers

@karenc-bq 
@sergiyv-bitquill 