### PR TITLE
Fix bug where EFM plugin was swallowing a communications exception

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ConnectionMethodAnalyzer.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ConnectionMethodAnalyzer.java
@@ -210,7 +210,7 @@ public class ConnectionMethodAnalyzer {
                 || MysqlErrorNumbers.SQL_STATE_COMMUNICATION_LINK_CHANGED.equals(sqlException.getSQLState());
     }
 
-    public boolean isCommunicationsException(Exception e) {
+    public boolean isCommunicationsException(Throwable e) {
         if (e instanceof CommunicationsException || e instanceof CJCommunicationsException) {
             return true;
         }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ConnectionMethodAnalyzer.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/ConnectionMethodAnalyzer.java
@@ -30,14 +30,7 @@
 package com.mysql.cj.jdbc.ha.plugins;
 
 import com.mysql.cj.Messages;
-import com.mysql.cj.exceptions.CJCommunicationsException;
-import com.mysql.cj.exceptions.CJException;
-import com.mysql.cj.exceptions.MysqlErrorNumbers;
-import com.mysql.cj.jdbc.exceptions.CommunicationsException;
-import com.mysql.cj.jdbc.ha.ConnectionUtils;
 
-import javax.net.ssl.SSLException;
-import java.io.EOFException;
 import java.sql.SQLException;
 
 public class ConnectionMethodAnalyzer {
@@ -198,37 +191,5 @@ public class ConnectionMethodAnalyzer {
         } else {
             throw new SQLException(Messages.getString("ConnectionMethodAnalyzer.1"));
         }
-    }
-
-    public boolean isFailoverException(Exception e) {
-        if (!(e instanceof SQLException)) {
-            return false;
-        }
-
-        SQLException sqlException = (SQLException) e;
-        return MysqlErrorNumbers.SQL_STATE_TRANSACTION_RESOLUTION_UNKNOWN.equals(sqlException.getSQLState())
-                || MysqlErrorNumbers.SQL_STATE_COMMUNICATION_LINK_CHANGED.equals(sqlException.getSQLState());
-    }
-
-    public boolean isCommunicationsException(Throwable e) {
-        if (e instanceof CommunicationsException || e instanceof CJCommunicationsException) {
-            return true;
-        }
-
-        if (e instanceof SQLException) {
-            return ConnectionUtils.isNetworkException((SQLException) e);
-        }
-
-        if (e instanceof CJException) {
-            if (e.getCause() instanceof EOFException) { // Can not read response from server
-                return true;
-            }
-            if (e.getCause() instanceof SSLException) { // Incomplete packets from server may cause SSL communication issues
-                return true;
-            }
-            return ConnectionUtils.isNetworkException(((CJException) e).getSQLState());
-        }
-
-        return false;
     }
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/NodeMonitoringConnectionPluginFactory.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/NodeMonitoringConnectionPluginFactory.java
@@ -34,6 +34,8 @@ package com.mysql.cj.jdbc.ha.plugins;
 import com.mysql.cj.conf.PropertySet;
 import com.mysql.cj.log.Log;
 
+import java.sql.SQLException;
+
 /**
  * Class initializing a {@link NodeMonitoringConnectionPlugin}.
  */
@@ -43,7 +45,7 @@ public class NodeMonitoringConnectionPluginFactory implements IConnectionPluginF
       ICurrentConnectionProvider currentConnectionProvider,
       PropertySet propertySet,
       IConnectionPlugin nextPlugin,
-      Log logger) {
+      Log logger) throws SQLException {
     return new NodeMonitoringConnectionPlugin(currentConnectionProvider, propertySet, nextPlugin, logger);
   }
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/NodeMonitoringConnectionPluginFactory.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/NodeMonitoringConnectionPluginFactory.java
@@ -34,8 +34,6 @@ package com.mysql.cj.jdbc.ha.plugins;
 import com.mysql.cj.conf.PropertySet;
 import com.mysql.cj.log.Log;
 
-import java.sql.SQLException;
-
 /**
  * Class initializing a {@link NodeMonitoringConnectionPlugin}.
  */
@@ -45,7 +43,7 @@ public class NodeMonitoringConnectionPluginFactory implements IConnectionPluginF
       ICurrentConnectionProvider currentConnectionProvider,
       PropertySet propertySet,
       IConnectionPlugin nextPlugin,
-      Log logger) throws SQLException {
+      Log logger) {
     return new NodeMonitoringConnectionPlugin(currentConnectionProvider, propertySet, nextPlugin, logger);
   }
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
@@ -46,7 +46,7 @@ import com.mysql.cj.jdbc.exceptions.SQLError;
 import com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping;
 import com.mysql.cj.jdbc.ha.ConnectionUtils;
 import com.mysql.cj.jdbc.ha.plugins.BasicConnectionProvider;
-import com.mysql.cj.jdbc.ha.plugins.ConnectionMethodAnalyzer;
+import com.mysql.cj.jdbc.ha.plugins.ExceptionAnalyzer;
 import com.mysql.cj.jdbc.ha.plugins.IConnectionPlugin;
 import com.mysql.cj.jdbc.ha.plugins.IConnectionProvider;
 import com.mysql.cj.jdbc.ha.plugins.ICurrentConnectionProvider;
@@ -97,7 +97,7 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
   protected final IClusterAwareMetricsContainer metricsContainer;
   private final ICurrentConnectionProvider currentConnectionProvider;
   private final RdsHostUtils rdsHostUtils;
-  private final ConnectionMethodAnalyzer connectionMethodAnalyzer;
+  private final ExceptionAnalyzer exceptionAnalyzer;
   private final PropertySet propertySet;
   private final IConnectionPlugin nextPlugin;
   private final Log logger;
@@ -145,7 +145,7 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
     this(
         currentConnectionProvider,
         new RdsHostUtils(logger),
-        new ConnectionMethodAnalyzer(),
+        new ExceptionAnalyzer(),
         propertySet,
         nextPlugin,
         logger,
@@ -157,7 +157,7 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
   FailoverConnectionPlugin(
       ICurrentConnectionProvider currentConnectionProvider,
       RdsHostUtils rdsHostUtils,
-      ConnectionMethodAnalyzer connectionMethodAnalyzer,
+      ExceptionAnalyzer exceptionAnalyzer,
       PropertySet propertySet,
       IConnectionPlugin nextPlugin,
       Log logger,
@@ -166,7 +166,7 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
       Supplier<IClusterAwareMetricsContainer> metricsContainerSupplier) throws SQLException {
     this.currentConnectionProvider = currentConnectionProvider;
     this.rdsHostUtils = rdsHostUtils;
-    this.connectionMethodAnalyzer = connectionMethodAnalyzer;
+    this.exceptionAnalyzer = exceptionAnalyzer;
     this.propertySet = propertySet;
     this.nextPlugin = nextPlugin;
     this.logger = logger;
@@ -628,7 +628,7 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
       return false;
     }
 
-    return this.connectionMethodAnalyzer.isCommunicationsException(t);
+    return this.exceptionAnalyzer.isCommunicationsException(t);
   }
 
   /**

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/NodeMonitoringConnectionPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/NodeMonitoringConnectionPluginTest.java
@@ -31,18 +31,6 @@
 
 package com.mysql.cj.jdbc.ha.plugins;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anySet;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.atMostOnce;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.mysql.cj.conf.DefaultPropertySet;
 import com.mysql.cj.conf.HostInfo;
 import com.mysql.cj.conf.PropertyKey;
@@ -63,10 +51,23 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atMostOnce;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class NodeMonitoringConnectionPluginTest {
   static final String NODE = "node";
@@ -227,8 +228,9 @@ class NodeMonitoringConnectionPluginTest {
         eq(EMPTY_ARGS));
   }
 
-  private void initializePlugin() {
+  private void initializePlugin() throws SQLException {
     plugin = new NodeMonitoringConnectionPlugin(proxy,
+        new ConnectionMethodAnalyzer(),
         propertySet,
         mockPlugin,
         logger,

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/NodeMonitoringConnectionPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/NodeMonitoringConnectionPluginTest.java
@@ -230,7 +230,6 @@ class NodeMonitoringConnectionPluginTest {
 
   private void initializePlugin() throws SQLException {
     plugin = new NodeMonitoringConnectionPlugin(proxy,
-        new ConnectionMethodAnalyzer(),
         propertySet,
         mockPlugin,
         logger,

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPluginTest.java
@@ -31,19 +31,6 @@
 
 package com.mysql.cj.jdbc.ha.plugins.failover;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.refEq;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.mysql.cj.NativeSession;
 import com.mysql.cj.conf.ConnectionUrl;
 import com.mysql.cj.conf.HostInfo;
@@ -52,6 +39,7 @@ import com.mysql.cj.jdbc.ConnectionImpl;
 import com.mysql.cj.jdbc.JdbcConnection;
 import com.mysql.cj.jdbc.JdbcPropertySet;
 import com.mysql.cj.jdbc.JdbcPropertySetImpl;
+import com.mysql.cj.jdbc.ha.plugins.ConnectionMethodAnalyzer;
 import com.mysql.cj.jdbc.ha.plugins.IConnectionPlugin;
 import com.mysql.cj.jdbc.ha.plugins.IConnectionProvider;
 import com.mysql.cj.jdbc.ha.plugins.ICurrentConnectionProvider;
@@ -71,6 +59,19 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class FailoverConnectionPluginTest {
   private static final String PREFIX = "jdbc:mysql:aws://";
@@ -666,6 +667,7 @@ class FailoverConnectionPluginTest {
     return new FailoverConnectionPlugin(
         mockCurrentConnectionProvider,
         new RdsHostUtils(mockLogger),
+        new ConnectionMethodAnalyzer(),
         propertySet,
         mockNextPlugin,
         mockLogger,

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPluginTest.java
@@ -39,7 +39,7 @@ import com.mysql.cj.jdbc.ConnectionImpl;
 import com.mysql.cj.jdbc.JdbcConnection;
 import com.mysql.cj.jdbc.JdbcPropertySet;
 import com.mysql.cj.jdbc.JdbcPropertySetImpl;
-import com.mysql.cj.jdbc.ha.plugins.ConnectionMethodAnalyzer;
+import com.mysql.cj.jdbc.ha.plugins.ExceptionAnalyzer;
 import com.mysql.cj.jdbc.ha.plugins.IConnectionPlugin;
 import com.mysql.cj.jdbc.ha.plugins.IConnectionProvider;
 import com.mysql.cj.jdbc.ha.plugins.ICurrentConnectionProvider;
@@ -667,7 +667,7 @@ class FailoverConnectionPluginTest {
     return new FailoverConnectionPlugin(
         mockCurrentConnectionProvider,
         new RdsHostUtils(mockLogger),
-        new ConnectionMethodAnalyzer(),
+        new ExceptionAnalyzer(),
         propertySet,
         mockNextPlugin,
         mockLogger,

--- a/src/test/java/testsuite/integration/container/standard/StandardMysqlReadWriteSplittingTest.java
+++ b/src/test/java/testsuite/integration/container/standard/StandardMysqlReadWriteSplittingTest.java
@@ -223,15 +223,6 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
     }
   }
 
-  /* Fails due to a bug:
-   *
-   * During the call to setReadOnly(true), NodeMonitoringConnectionPlugin#generateNodeKeys tries to execute some SQL
-   * which fails because the nodes were put down. As a result the connection gets closed, but the call to setReadOnly
-   * continues down the connection plugin chain until ConnectionImpl#setReadOnly throws a
-   * SQLNonTransientConnectionException: 'No operations allowed after connection closed'. This test should be enabled
-   * after this issue is fixed.
-   */
-  @Disabled
   @ParameterizedTest(name = "test_setReadOnlyTrue_allInstancesDown")
   @MethodSource("testParameters")
   public void test_setReadOnlyTrue_allInstancesDown(Properties props) throws SQLException, IOException {
@@ -246,10 +237,9 @@ public class StandardMysqlReadWriteSplittingTest extends StandardMysqlBaseTest {
           fail(String.format("%s does not have a proxy setup.", instanceId));
         }
       }
-      
-      assertDoesNotThrow(() -> conn.setReadOnly(true));
-      final SQLException exception = assertThrows(SQLException.class, () -> queryInstanceId(conn));
-      assertEquals(MysqlErrorNumbers.SQL_STATE_UNABLE_TO_CONNECT_TO_DATASOURCE, exception.getSQLState());
+
+      final SQLException exception = assertThrows(SQLException.class, () -> conn.setReadOnly(true));
+      assertEquals(MysqlErrorNumbers.SQL_STATE_COMMUNICATION_LINK_FAILURE, exception.getSQLState());
     }
   }
 


### PR DESCRIPTION
### Summary

Fix bug where EFM plugin was swallowing a communications exception

### Description

- Connections are automatically closed when communications exceptions
  occur, so the EFM plugin should throw them when encountered.
  Otherwise, the invoked method will continue down the plugin chain and
  execute against a closed connection. This can lead to a 'No
  operations allowed after connection closed' exception

### Additional Reviewers

@sergiyv-bitquill 
@karenc-bq 