### PR TITLE
fix: unwrap nested exceptions in AWS Secrets Manager Plugin when checking if the error is caused by invalid credentials

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/AWSSecretsManagerPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/AWSSecretsManagerPlugin.java
@@ -33,6 +33,7 @@ package com.mysql.cj.jdbc.ha.plugins;
 
 import com.mysql.cj.conf.ConnectionUrl;
 import com.mysql.cj.conf.PropertySet;
+import com.mysql.cj.exceptions.CJException;
 import com.mysql.cj.log.Log;
 import com.mysql.cj.util.LRUCache;
 
@@ -53,6 +54,7 @@ import java.util.Properties;
 import java.util.concurrent.Callable;
 
 public class AWSSecretsManagerPlugin implements IConnectionPlugin {
+
   static final String SECRET_ID_PROPERTY = "secretsManagerSecretId";
   static final String REGION_PROPERTY = "secretsManagerRegion";
   private static final String ERROR_MISSING_DEPENDENCY_SECRETS =
@@ -182,11 +184,17 @@ public class AWSSecretsManagerPlugin implements IConnectionPlugin {
 
     Throwable throwable = exception;
     while (throwable != null) {
+      String sqlState = "";
       if (throwable instanceof SQLException) {
-        if (SQLSTATE_ACCESS_ERROR.equals(((SQLException) throwable).getSQLState())) {
-          return true;
-        }
+        sqlState = ((SQLException) throwable).getSQLState();
+      } else if (throwable instanceof CJException) {
+        sqlState = ((CJException) throwable).getSQLState();
       }
+
+      if (SQLSTATE_ACCESS_ERROR.equals(sqlState)) {
+        return true;
+      }
+
       throwable = throwable.getCause();
     }
 
@@ -201,9 +209,9 @@ public class AWSSecretsManagerPlugin implements IConnectionPlugin {
   private void applySecretToProperties(Properties properties) {
     if (this.secret != null) {
       /** Updated credentials are stored in properties. Other plugins in the plugin chain may
-      * change them if needed. Eventually, credentials will be used to open a new connection in
-      * {@link DefaultConnectionPlugin#openInitialConnection}
-      */
+       * change them if needed. Eventually, credentials will be used to open a new connection in
+       * {@link DefaultConnectionPlugin#openInitialConnection}
+       */
       properties.put("user", secret.getUsername());
       properties.put("password", secret.getPassword());
     }
@@ -236,17 +244,18 @@ public class AWSSecretsManagerPlugin implements IConnectionPlugin {
   }
 
   /**
-   * Called to open a new connection. This plugin is responsible to providing a recent credentials and
-   * delegate actual opening a new connection to other plugins in the plugin chain. Eventually
-   * a new connection is handled either by some plugin, or by {@link DefaultConnectionPlugin#openInitialConnection}
+   * Called to open a new connection. This plugin is responsible to providing a recent credentials and delegate actual
+   * opening a new connection to other plugins in the plugin chain. Eventually a new connection is handled either by
+   * some plugin, or by {@link DefaultConnectionPlugin#openInitialConnection}
    *
-   * @param props Properties with updated credentials.
+   * @param props         Properties with updated credentials.
    * @param connectionUrl Original instance of ConnectionUrl
    */
   private void attemptToLogin(Properties props, ConnectionUrl connectionUrl)
       throws SQLException {
 
-    final ConnectionUrl newConnectionUrl = ConnectionUrl.getConnectionUrlInstance(connectionUrl.getDatabaseUrl(), props);
+    final ConnectionUrl newConnectionUrl = ConnectionUrl.getConnectionUrlInstance(connectionUrl.getDatabaseUrl(),
+        props);
     this.nextPlugin.openInitialConnection(newConnectionUrl);
   }
 
@@ -283,6 +292,7 @@ public class AWSSecretsManagerPlugin implements IConnectionPlugin {
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   static class Secret {
+
     @JsonProperty("username")
     private String username;
     @JsonProperty("password")

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/AWSSecretsManagerPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/AWSSecretsManagerPlugin.java
@@ -186,9 +186,8 @@ public class AWSSecretsManagerPlugin implements IConnectionPlugin {
         if (SQLSTATE_ACCESS_ERROR.equals(((SQLException) throwable).getSQLState())) {
           return true;
         }
-
-        throwable = throwable.getCause();
       }
+      throwable = throwable.getCause();
     }
 
     return false;

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/AWSSecretsManagerPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/AWSSecretsManagerPlugin.java
@@ -179,7 +179,19 @@ public class AWSSecretsManagerPlugin implements IConnectionPlugin {
    */
   private boolean isLoginUnsuccessful(SQLException exception) {
     this.logger.logTrace("Login failed. SQLState=" + exception.getSQLState(), exception);
-    return SQLSTATE_ACCESS_ERROR.equals(exception.getSQLState());
+
+    Throwable throwable = exception;
+    while (throwable != null) {
+      if (throwable instanceof SQLException) {
+        if (SQLSTATE_ACCESS_ERROR.equals(((SQLException) throwable).getSQLState())) {
+          return true;
+        }
+
+        throwable = throwable.getCause();
+      }
+    }
+
+    return false;
   }
 
   /**


### PR DESCRIPTION

### Summary

Unwrap nested exceptions in AWS Secrets Manager Plugin when checking if the error is caused by invalid credentials

### Description


### Additional Reviewers

@sergiyvamz 