### PR TITLE
feat: track whether the connection is currently in a prepared transaction state

### DIFF
--- a/src/main/user-api/java/com/mysql/cj/jdbc/JdbcConnection.java
+++ b/src/main/user-api/java/com/mysql/cj/jdbc/JdbcConnection.java
@@ -228,6 +228,21 @@ public interface JdbcConnection extends java.sql.Connection, MysqlConnection, Tr
      */
     void setInGlobalTx(boolean flag);
 
+    /**
+     * Is this connection currently in the prepared transaction state?
+     *
+     * @return true if this connection is currently in a prepared transaction state.
+     */
+    boolean isInPreparedTx();
+
+    /**
+     * Set the state of being in a prepared transaction.
+     *
+     * @param flag
+     *            the state flag
+     */
+    void setInPreparedTx(boolean flag);
+
     // TODO this and other multi-host connection specific methods should be moved to special interface
     /**
      * Is this connection connected to the first host in the list if

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ConnectionImpl.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ConnectionImpl.java
@@ -298,6 +298,9 @@ public class ConnectionImpl implements JdbcConnection, SessionEventListener, Ser
     /** Is this connection associated with a global tx? */
     private boolean isInGlobalTx = false;
 
+    /** Is this connection in a prepared tx? */
+    private boolean isInPreparedTx = false;
+
     /** isolation level */
     private int isolationLevel = java.sql.Connection.TRANSACTION_READ_COMMITTED;
 
@@ -2177,6 +2180,16 @@ public class ConnectionImpl implements JdbcConnection, SessionEventListener, Ser
     @Override
     public void setInGlobalTx(boolean flag) {
         this.isInGlobalTx = flag;
+    }
+
+    @Override
+    public boolean isInPreparedTx() {
+        return this.isInPreparedTx;
+    }
+
+    @Override
+    public void setInPreparedTx(boolean flag) {
+        this.isInPreparedTx = flag;
     }
 
     @Override

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ConnectionWrapper.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ConnectionWrapper.java
@@ -605,6 +605,16 @@ public class ConnectionWrapper extends WrapperBase implements JdbcConnection {
     }
 
     @Override
+    public boolean isInPreparedTx() {
+        return this.mc.isInPreparedTx();
+    }
+
+    @Override
+    public void setInPreparedTx(boolean flag) {
+        this.mc.setInPreparedTx(flag);
+    }
+
+    @Override
     public void ping() throws SQLException {
         if (this.mc != null) {
             this.mc.ping();

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/MysqlXAConnection.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/MysqlXAConnection.java
@@ -223,9 +223,12 @@ public class MysqlXAConnection extends MysqlPooledConnection implements XAConnec
         commandBuf.append("XA PREPARE ");
         appendXid(commandBuf, xid);
 
-        dispatchCommand(commandBuf.toString());
-
-        return XA_OK; // TODO: Check for read-only
+        try {
+            dispatchCommand(commandBuf.toString());
+            return XA_OK; // TODO: Check for read-only
+        } finally {
+            this.underlyingConnection.setInPreparedTx(true);
+        }
     }
 
     @Override
@@ -243,6 +246,7 @@ public class MysqlXAConnection extends MysqlPooledConnection implements XAConnec
             dispatchCommand(commandBuf.toString());
         } finally {
             this.underlyingConnection.setInGlobalTx(false);
+            this.underlyingConnection.setInPreparedTx(false);
         }
     }
 
@@ -306,6 +310,7 @@ public class MysqlXAConnection extends MysqlPooledConnection implements XAConnec
             dispatchCommand(commandBuf.toString());
         } finally {
             this.underlyingConnection.setInGlobalTx(false);
+            this.underlyingConnection.setInPreparedTx(false);
         }
     }
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/MultiHostMySQLConnection.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/MultiHostMySQLConnection.java
@@ -343,6 +343,11 @@ public class MultiHostMySQLConnection implements JdbcConnection {
     }
 
     @Override
+    public boolean isInPreparedTx() {
+        return getActiveMySQLConnection().isInPreparedTx();
+    }
+
+    @Override
     public boolean isSourceConnection() {
         return getThisAsProxy().isSourceConnection();
     }
@@ -530,6 +535,11 @@ public class MultiHostMySQLConnection implements JdbcConnection {
     @Override
     public void setInGlobalTx(boolean flag) {
         getActiveMySQLConnection().setInGlobalTx(flag);
+    }
+
+    @Override
+    public void setInPreparedTx(boolean flag) {
+        getActiveMySQLConnection().setInPreparedTx(flag);
     }
 
     @Override

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
@@ -704,11 +704,12 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
 
   protected void updateTopologyAndConnectIfNeeded(boolean forceUpdate)
       throws SQLException {
-    JdbcConnection connection = this.currentConnectionProvider.getCurrentConnection();
+    final JdbcConnection connection = this.currentConnectionProvider.getCurrentConnection();
     if (!isFailoverEnabled()
         || connection == null
-        || connection.isClosed()) {
-      return;
+        || connection.isClosed()
+        || connection.isInPreparedTx()) {
+        return;
     }
 
     List<HostInfo> latestTopology =


### PR DESCRIPTION
### Summary

Keep track of the connection's XA transaction state to avoid querying for topology during the `PREPARED` state.

### Description

#292 

### Additional Reviewers

@sergiyvamz 