### PR TITLE
fix: after Aurora failover, failover is disabled in FailoverConnectionPlugin and re-connection can target the wrong host

### DIFF
--- a/src/main/core-api/java/com/mysql/cj/conf/HostInfo.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/HostInfo.java
@@ -34,6 +34,7 @@ import static com.mysql.cj.util.StringUtils.isNullOrEmpty;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 
 /**
@@ -237,5 +238,18 @@ public class HostInfo implements DatabaseUrlContainer {
         StringBuilder asStr = new StringBuilder(super.toString());
         asStr.append(String.format(" :: {host: \"%s\", port: %d, hostProperties: %s}", this.host, this.port, this.hostProperties));
         return asStr.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HostInfo hostInfo = (HostInfo) o;
+        return port == hostInfo.port && Objects.equals(originalUrl, hostInfo.originalUrl) && Objects.equals(host, hostInfo.host) && Objects.equals(user, hostInfo.user) && Objects.equals(password, hostInfo.password) && Objects.equals(hostProperties, hostInfo.hostProperties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(originalUrl, host, port, user, password, hostProperties);
     }
 }

--- a/src/main/core-api/java/com/mysql/cj/log/Log.java
+++ b/src/main/core-api/java/com/mysql/cj/log/Log.java
@@ -38,49 +38,49 @@ public interface Log {
 
     /**
      * Is the 'debug' log level enabled?
-     * 
+     *
      * @return true if so.
      */
     boolean isDebugEnabled();
 
     /**
      * Is the 'error' log level enabled?
-     * 
+     *
      * @return true if so.
      */
     boolean isErrorEnabled();
 
     /**
      * Is the 'fatal' log level enabled?
-     * 
+     *
      * @return true if so.
      */
     boolean isFatalEnabled();
 
     /**
      * Is the 'info' log level enabled?
-     * 
+     *
      * @return true if so.
      */
     boolean isInfoEnabled();
 
     /**
      * Is the 'trace' log level enabled?
-     * 
+     *
      * @return true if so.
      */
     boolean isTraceEnabled();
 
     /**
      * Is the 'warn' log level enabled?
-     * 
+     *
      * @return true if so.
      */
     boolean isWarnEnabled();
 
     /**
      * Logs the given message instance using the 'debug' level
-     * 
+     *
      * @param msg
      *            the message to log
      */
@@ -88,7 +88,7 @@ public interface Log {
 
     /**
      * Logs the given message and Throwable at the 'debug' level.
-     * 
+     *
      * @param msg
      *            the message to log
      * @param thrown
@@ -98,7 +98,7 @@ public interface Log {
 
     /**
      * Logs the given message instance using the 'error' level
-     * 
+     *
      * @param msg
      *            the message to log
      */
@@ -106,7 +106,7 @@ public interface Log {
 
     /**
      * Logs the given message and Throwable at the 'error' level.
-     * 
+     *
      * @param msg
      *            the message to log
      * @param thrown
@@ -116,7 +116,7 @@ public interface Log {
 
     /**
      * Logs the given message instance using the 'fatal' level
-     * 
+     *
      * @param msg
      *            the message to log
      */
@@ -124,7 +124,7 @@ public interface Log {
 
     /**
      * Logs the given message and Throwable at the 'fatal' level.
-     * 
+     *
      * @param msg
      *            the message to log
      * @param thrown
@@ -134,7 +134,7 @@ public interface Log {
 
     /**
      * Logs the given message instance using the 'info' level
-     * 
+     *
      * @param msg
      *            the message to log
      */
@@ -142,7 +142,7 @@ public interface Log {
 
     /**
      * Logs the given message and Throwable at the 'info' level.
-     * 
+     *
      * @param msg
      *            the message to log
      * @param thrown
@@ -152,7 +152,7 @@ public interface Log {
 
     /**
      * Logs the given message instance using the 'trace' level
-     * 
+     *
      * @param msg
      *            the message to log
      */
@@ -160,7 +160,7 @@ public interface Log {
 
     /**
      * Logs the given message and Throwable at the 'trace' level.
-     * 
+     *
      * @param msg
      *            the message to log
      * @param thrown
@@ -170,7 +170,7 @@ public interface Log {
 
     /**
      * Logs the given message instance using the 'warn' level
-     * 
+     *
      * @param msg
      *            the message to log
      */
@@ -178,11 +178,28 @@ public interface Log {
 
     /**
      * Logs the given message and Throwable at the 'warn' level.
-     * 
+     *
      * @param msg
      *            the message to log
      * @param thrown
      *            the throwable to log (may be null)
      */
     void logWarn(Object msg, Throwable thrown);
+
+    /**
+     * Add a property to the logging context. Supported by Slf4j
+     * @param key non-null key
+     * @param value value
+     */
+    default void contextAdd(String key, String value) {
+        // no-op
+    }
+
+    /**
+     * Remove a property from the logging context. Supported by Slf4j
+     * @param key non-null key
+     */
+    default void contextRemove(String key) {
+        // no-op
+    }
 }

--- a/src/main/core-api/java/com/mysql/cj/log/Slf4JLogger.java
+++ b/src/main/core-api/java/com/mysql/cj/log/Slf4JLogger.java
@@ -31,6 +31,7 @@ package com.mysql.cj.log;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 public class Slf4JLogger implements Log {
     private Logger log;
@@ -111,4 +112,13 @@ public class Slf4JLogger implements Log {
         this.log.warn(msg.toString(), thrown);
     }
 
+    @Override
+    public void contextAdd(String key, String value) {
+        MDC.put(key, value);
+    }
+
+    @Override
+    public void contextRemove(String key) {
+        MDC.remove(key);
+    }
 }

--- a/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
+++ b/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
@@ -1055,6 +1055,8 @@ ConnectionProperties.useAwsIam=Set to true to use AWS IAM database authenticatio
 AuroraTopologyService.1=[AuroraTopologyService] clusterId=''{0}''
 AuroraTopologyService.2=[AuroraTopologyService] clusterInstance host=''{0}'', port={1,number,#}, database=''{2}''
 AuroraTopologyService.3=[AuroraTopologyService] The topology query returned an invalid topology - no writer instance detected
+AuroraTopologyService.4=[AuroraTopologyService] Topology obtained from database: {0}
+AuroraTopologyService.5=[AuroraTopologyService] Topology updated: {0}
 
 ClusterAwareConnectionProxy.1=Transaction resolution unknown. Please re-configure session state if required and try restarting transaction.
 ClusterAwareConnectionProxy.2=Unable to establish SQL connection to writer node.
@@ -1077,6 +1079,7 @@ ClusterAwareConnectionProxy.18=An RDS Custom Cluster endpoint can't be used as t
 ClusterAwareConnectionProxy.19=The active SQL connection has changed. Please re-configure session state if required.
 ClusterAwareConnectionProxy.20=The provided connection string does not appear to match an expected Aurora DNS pattern. Please set the 'clusterInstanceHostPattern' configuration property to specify the host pattern for the cluster you are trying to connect to.
 ClusterAwareConnectionProxy.21=Invalid value for the 'clusterInstanceHostPattern' configuration setting - the host pattern must contain a '?' character as a placeholder for the DB instance identifiers of the instances in the cluster
+ClusterAwareConnectionProxy.22=[ClusterAwareConnectionProxy] Hosts updated: {0}
 
 ClusterAwareWriterFailoverHandler.1=Thread was interrupted.
 ClusterAwareWriterFailoverHandler.2=[ClusterAwareWriterFailoverHandler] Successfully re-connected to the current writer instance: ''{0}''


### PR DESCRIPTION
### Summary

This PR fixes several issues during re-connection after failover:
* if the topology has only one host (this happens after a replica is promoted to writer, and before the previous writer has restarted
* `FailoverConnectionPlugin.pickNewConnection` is using stale topology, so it does not reconnect to the expected host
* if hosts are switched (replica became writer, writer became replica), `FailoverConnectionPlugin.updateHostIndex` will keep the connection to the same host, although that host is now the replica

### Description

Most changes are clear in `FailoverConnectionPlugin`, and covered by unit tests.
I've added logging in several places in order to investigate this issue, and that includes the stack trace when the same messages are logged in multiple places. debug and trace logging are enclosed in tests to check the logging level first.

