### PR TITLE
feat: add enableFailoverStrictReader parameter

### DIFF
--- a/src/main/core-api/java/com/mysql/cj/conf/PropertyDefinitions.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/PropertyDefinitions.java
@@ -664,6 +664,11 @@ public class PropertyDefinitions {
                 new BooleanPropertyDefinition(PropertyKey.enableClusterAwareFailover, DEFAULT_VALUE_TRUE, RUNTIME_MODIFIABLE,
                         Messages.getString("ConnectionProperties.enableClusterAwareFailover"), "0.1.0", CATEGORY_HA, Integer.MAX_VALUE),
 
+                new BooleanPropertyDefinition(PropertyKey.enableFailoverStrictReader, DEFAULT_VALUE_FALSE,
+                    RUNTIME_MODIFIABLE,
+                    Messages.getString("ConnectionProperties.enableFailoverStrictReader"), "1.1.2", CATEGORY_HA,
+                    Integer.MAX_VALUE),
+
                 new BooleanPropertyDefinition(PropertyKey.gatherAdditionalMetricsOnInstance, DEFAULT_VALUE_FALSE, RUNTIME_MODIFIABLE,
                     Messages.getString("ConnectionProperties.gatherAdditionalMetricsOnInstance"), "0.4.0", CATEGORY_HA, Integer.MAX_VALUE),
 

--- a/src/main/core-api/java/com/mysql/cj/conf/PropertyKey.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/PropertyKey.java
@@ -288,6 +288,7 @@ public enum PropertyKey {
 
     // Failover plugin
     enableClusterAwareFailover("enableClusterAwareFailover", true), //
+    enableFailoverStrictReader("enableFailoverStrictReader", true), //
     gatherAdditionalMetricsOnInstance("gatherAdditionalMetricsOnInstance", true),
     clusterInstanceHostPattern("clusterInstanceHostPattern", true), // "?.my-domain.com", "any-subdomain.?.my-domain.com:9999"; "?" will be replaced with node name
     clusterId("clusterId", true), //

--- a/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
+++ b/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
@@ -1038,6 +1038,7 @@ ConnectionProperties.useConnectionPlugins=Use connection plugins to execute JDBC
 ConnectionProperties.enableClusterAwareFailover=Enable/disable cluster-aware failover logic. 
 ConnectionProperties.gatherAdditionalMetricsOnInstance=Enable to gather additional performance metrics per instance on top of cluster. Disable to only gather performance metrics per cluster. 
 ConnectionProperties.clusterTopologyRefreshRateMs=Cluster topology refresh rate in millis. The cached topology for the cluster will be invalidated after the specified time, after which it will be updated during the next interaction with the connection.
+ConnectionProperties.enableFailoverStrictReader=Set to true to only allow failover to reader nodes during the reader failover process. If enabled, reader failover to a writer node will only be allowed for single-node clusters. This logic mimics the logic of the Aurora read-only cluster endpoint.
 ConnectionProperties.failoverTimeoutMs=Maximum allowed time in millis to attempt reconnecting to a new writer or reader instance after a cluster failover is initiated.
 ConnectionProperties.failoverClusterTopologyRefreshRateMs=Cluster topology refresh rate in millis during a writer failover process. During the writer failover process, cluster topology may be refreshed at a faster pace than normal to speed up discovery of the newly promoted writer.
 ConnectionProperties.failoverWriterReconnectIntervalMs=Interval of time to wait between attempts to reconnect to a failed writer during a writer failover process.

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
@@ -129,6 +129,7 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
 
   // Configuration settings
   protected boolean enableFailoverSetting = true;
+  protected boolean enableFailoverStrictReaderSetting;
   protected int clusterTopologyRefreshRateMsSetting;
   protected int failoverTimeoutMsSetting;
   protected int failoverClusterTopologyRefreshRateMsSetting;
@@ -198,6 +199,7 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
             this.initialConnectionProps,
             this.failoverTimeoutMsSetting,
             this.failoverReaderConnectTimeoutMsSetting,
+            this.enableFailoverStrictReaderSetting,
             this.logger);
     this.writerFailoverHandler =
         new ClusterAwareWriterFailoverHandler(
@@ -334,6 +336,9 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
     this.autoReconnect =
       propertySet.getBooleanProperty(PropertyKey.autoReconnect.getKeyName()).getValue()
       || propertySet.getBooleanProperty(PropertyKey.autoReconnectForPools.getKeyName()).getValue();
+
+    this.enableFailoverStrictReaderSetting =
+        propertySet.getBooleanProperty(PropertyKey.enableFailoverStrictReader.getKeyName()).getValue();
   }
 
   /**


### PR DESCRIPTION
### Summary

Add enableFailoverStrictReader parameter so the driver only failovers to reader nodes.

### Description

<!--- Details of what you changed -->

### Additional Reviewers

@sergiyvamz 
@congoamz 