### PR TITLE
fix: update topology and check current node role after writer failover

### DIFF
--- a/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
+++ b/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
@@ -1095,7 +1095,8 @@ ClusterAwareWriterFailoverHandler.13=[ClusterAwareWriterFailoverHandler] [TaskB]
 ClusterAwareWriterFailoverHandler.14=[ClusterAwareWriterFailoverHandler] [TaskB] Trying to connect to a new writer ''{0}''
 ClusterAwareWriterFailoverHandler.15=[ClusterAwareWriterFailoverHandler] [TaskB] encountered an exception:
 ClusterAwareWriterFailoverHandler.16=[ClusterAwareWriterFailoverHandler] [TaskA] encountered an exception:
-
+ClusterAwareWriterFailoverHandler.17=[ClusterAwareWriterFailoverHandler] [TaskB] Host {0} is not yet connected to a cluster. The cluster is still being reconfigured.
+ClusterAwareWriterFailoverHandler.18=[ClusterAwareWriterFailoverHandler] Current reader connection is actually a new writer connection.
 ClusterAwareReaderFailoverHandler.1=Thread was interrupted.
 ClusterAwareReaderFailoverHandler.2=[ClusterAwareReaderFailoverHandler] Connected to reader [{0,number,#}]
 ClusterAwareReaderFailoverHandler.3=[ClusterAwareReaderFailoverHandler] Trying to connect to reader [{0,number,#}] ''{1}''


### PR DESCRIPTION
### Summary

fix: update topology and check current node role after writer failover

### Description

- ensure writer failover does not reconnect to a reader node due to stale topology

### Additional Reviewers

@congoamz 
@sergiyvamz 