### PR TITLE
Fix 308: Statements with same ConnectionProxy should be distinct

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ConnectionProxy.java
@@ -309,9 +309,6 @@ public class ConnectionProxy implements ICurrentConnectionProvider, InvocationHa
 
     public synchronized Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
       final String methodName = method.getName();
-      if (isDirectExecute(methodName)) {
-        return executeMethodDirectly(methodName, args);
-      }
 
       Object[] argsCopy = args == null ? null : Arrays.copyOf(args, args.length);
 


### PR DESCRIPTION
Fix hashCode and equals methods for ClientPreparedStatements created by the same ConnectionProxy. Distinct Statements that share the same ConnectionProxy should not have the same hash code value and should not be equal via the equals() method.

### Summary

See https://github.com/awslabs/aws-mysql-jdbc/issues/308

Fix hashCode and equals methods for ClientPreparedStatements created by the same ConnectionProxy. Distinct Statements that share the same ConnectionProxy should not have the same hash code value and should not be equal via the equals() method.

### Description

Removed code to use the equals and hashcode implementations of the ConnectionProxy object and instead deferring to the underlying object's implementation.

### Additional Reviewers

