### PR TITLE
chore: remove SNAPSHOT from the full version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -267,7 +267,7 @@ tasks.register<Sync>("replaceTokens") {
     val git = org.ajoberstar.grgit.Grgit.open(mapOf("currentDir" to project.rootDir))
     val revision = git.head().id
 
-    val versionFull = "$versionMajor.$versionMinor.$versionSubminor-SNAPSHOT"
+    val versionFull = "$versionMajor.$versionMinor.$versionSubminor"
 
     val fullProdName = "${project.property("com.mysql.cj.build.driver.name")}-$versionFull"
 


### PR DESCRIPTION
### Summary

Remove the SNAPSHOT string from the versioning

### Description

`DatabaseMetaData#getDriverVersion` returns the full product name and version with "SNAPSHOT" attached, e.g. `aws-mysql-connector-java-1.1.2-SNAPSHOT` 

Remove the SNAPSHOT string from the versioning.

Addresses #318 

### Additional Reviewers

@aaron-congo 
@hsuamz 