### PR TITLE
fix: versioning not being picked up during build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 val versionMajor = project.property("com.mysql.cj.build.driver.version.major")
 val versionMinor = project.property("com.mysql.cj.build.driver.version.minor")
 val versionSubminor = Integer.parseInt(project.property("com.mysql.cj.build.driver.version.subminor").toString()) + if (project.property("snapshot") == "true") 1 else 0
-val version = "$versionMajor.$versionMinor.$versionSubminor" + if (project.property("snapshot") == "true") "-SNAPSHOT" else ""
+version = "$versionMajor.$versionMinor.$versionSubminor" + if (project.property("snapshot") == "true") "-SNAPSHOT" else ""
 
 plugins {
     base
@@ -267,12 +267,14 @@ tasks.register<Sync>("replaceTokens") {
     val git = org.ajoberstar.grgit.Grgit.open(mapOf("currentDir" to project.rootDir))
     val revision = git.head().id
 
-    val fullProdName = "${project.property("com.mysql.cj.build.driver.name")}-$version"
+    val versionFull = "$this.version"
+
+    val fullProdName = "${project.property("com.mysql.cj.build.driver.name")}-$versionFull"
 
     filter(ReplaceTokens::class, "tokens" to mapOf(
             "MYSQL_CJ_MAJOR_VERSION" to versionMajor,
             "MYSQL_CJ_MINOR_VERSION" to versionMinor,
-            "MYSQL_CJ_VERSION" to version,
+            "MYSQL_CJ_VERSION" to versionFull,
             "MYSQL_CJ_FULL_PROD_NAME" to fullProdName,
             "MYSQL_CJ_DISPLAY_PROD_NAME" to project.property("com.mysql.cj.build.driver.displayName"),
             "MYSQL_CJ_LICENSE_TYPE" to project.property("com.mysql.cj.build.licenseType"),


### PR DESCRIPTION
### Summary

Fix versioning not appearing in the final JAR file.

### Description

https://github.com/awslabs/aws-mysql-jdbc/actions/runs/3651103166/jobs/6167915405
The built JARs are unable to pick up the versioning, they are built as `aws-mysql-jdbc.jar` instead of the expected `aws-mysql-jdbc-1.1.2.jar`

### Additional Reviewers
@congoamz 
@sergiyvamz 