### PR TITLE
Update driver name in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ dependencies {
 The AWS JDBC Driver for MySQL is drop-in compatible, so usage is identical to the [MySQL-Connector-J JDBC driver](https://github.com/mysql/mysql-connector-j). The sections below highlight driver usage specific to failover.
 
 #### Driver Name
-Use the driver name: ```software.aws.rds.jdbc.Driver```. If you are building the driver directly from main, use the driver name: ```software.aws.rds.jdbc.mysql.Driver```. You'll need the driver name when loading the driver explicitly to the driver manager.
+Use the driver name: ```software.aws.rds.jdbc.mysql.Driver```. You'll need the driver name when loading the driver explicitly to the driver manager.
 
 ### Connection URL Descriptions
 


### PR DESCRIPTION
### Summary

In https://github.com/awslabs/aws-mysql-jdbc/pull/34 it looks like the driver name was changed to `software.aws.rds.jdbc.mysql.Driver`. The current readme still suggests the old driver name even though this change now looks to be live.

### Description

Readme has been updated with the current driver name.
