### PR TITLE
Fix - updating topology and connection switching to not use stale data

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
@@ -641,7 +641,10 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
 
   protected boolean shouldExceptionTriggerConnectionSwitch(Throwable t) {
 
-    if (!isFailoverEnabled()) {
+    if (!this.enableFailoverSetting
+        || this.isRdsProxy
+        || !this.isClusterTopologyAvailable
+        || this.isMultiWriterCluster) {
       this.logger.logDebug(Messages.getString("ClusterAwareConnectionProxy.13"));
       return false;
     }
@@ -710,11 +713,14 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
   protected void updateTopologyAndConnectIfNeeded(boolean forceUpdate)
       throws SQLException {
     final JdbcConnection connection = this.currentConnectionProvider.getCurrentConnection();
-    if (!isFailoverEnabled()
-        || connection == null
-        || connection.isClosed()
-        || connection.isInPreparedTx()) {
-        return;
+    if (
+        !this.enableFailoverSetting
+            || this.isRdsProxy
+            || !this.isClusterTopologyAvailable
+            || connection == null
+            || connection.isClosed()
+            || connection.isInPreparedTx()) {
+      return;
     }
 
     List<HostInfo> latestTopology =


### PR DESCRIPTION
### Summary

Addresses some issues regarding using stale topology and connecting switching 

### Description

Changed the criteria for updateTopologyAndConnectIfNeeded() and shouldExceptionTriggerConnectionSwitch() to not rely on isFailoverEnabled() since it may be using a stale host list.

### Additional Reviewers

@sergiyv-improving @karenc-bq 
