### PR TITLE
fix: class cast exception on proxy objects

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/BestResponseTimeBalanceStrategy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/BestResponseTimeBalanceStrategy.java
@@ -78,9 +78,9 @@ public class BestResponseTimeBalanceStrategy implements BalanceStrategy {
             String bestHost = configuredHosts.get(bestHostIndex);
 
             final JdbcConnection wrappedConnection = liveConnections.get(bestHost);
-            ConnectionImpl conn = wrappedConnection instanceof ConnectionImpl
-                ? ((ConnectionImpl) wrappedConnection)
-                : wrappedConnection.unwrap(ConnectionImpl.class);
+            ConnectionImpl conn = !(wrappedConnection instanceof ConnectionImpl) && wrappedConnection != null
+                ? wrappedConnection.unwrap(ConnectionImpl.class)
+                : ((ConnectionImpl) wrappedConnection);
 
             if (conn == null) {
                 try {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/BestResponseTimeBalanceStrategy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/BestResponseTimeBalanceStrategy.java
@@ -77,7 +77,10 @@ public class BestResponseTimeBalanceStrategy implements BalanceStrategy {
 
             String bestHost = configuredHosts.get(bestHostIndex);
 
-            ConnectionImpl conn = (ConnectionImpl) liveConnections.get(bestHost);
+            final JdbcConnection wrappedConnection = liveConnections.get(bestHost);
+            ConnectionImpl conn = wrappedConnection instanceof ConnectionImpl
+                ? ((ConnectionImpl) wrappedConnection)
+                : wrappedConnection.unwrap(ConnectionImpl.class);
 
             if (conn == null) {
                 try {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/RandomBalanceStrategy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/RandomBalanceStrategy.java
@@ -71,9 +71,9 @@ public class RandomBalanceStrategy implements BalanceStrategy {
             String hostPortSpec = allowList.get(random);
 
             final JdbcConnection wrappedConnection = liveConnections.get(hostPortSpec);
-            ConnectionImpl conn = wrappedConnection instanceof ConnectionImpl
-                ? ((ConnectionImpl) wrappedConnection)
-                : wrappedConnection.unwrap(ConnectionImpl.class);
+            ConnectionImpl conn = !(wrappedConnection instanceof ConnectionImpl) && wrappedConnection != null
+                ? wrappedConnection.unwrap(ConnectionImpl.class)
+                : ((ConnectionImpl) wrappedConnection);
 
             if (conn == null) {
                 try {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/RandomBalanceStrategy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/RandomBalanceStrategy.java
@@ -70,7 +70,10 @@ public class RandomBalanceStrategy implements BalanceStrategy {
 
             String hostPortSpec = allowList.get(random);
 
-            ConnectionImpl conn = (ConnectionImpl) liveConnections.get(hostPortSpec);
+            final JdbcConnection wrappedConnection = liveConnections.get(hostPortSpec);
+            ConnectionImpl conn = wrappedConnection instanceof ConnectionImpl
+                ? ((ConnectionImpl) wrappedConnection)
+                : wrappedConnection.unwrap(ConnectionImpl.class);
 
             if (conn == null) {
                 try {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/SequentialBalanceStrategy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/SequentialBalanceStrategy.java
@@ -128,7 +128,10 @@ public class SequentialBalanceStrategy implements BalanceStrategy {
 
             String hostPortSpec = configuredHosts.get(this.currentHostIndex);
 
-            ConnectionImpl conn = (ConnectionImpl) liveConnections.get(hostPortSpec);
+            JdbcConnection wrappedConnection = liveConnections.get(hostPortSpec);
+            ConnectionImpl conn = !(wrappedConnection instanceof ConnectionImpl) && wrappedConnection != null
+                ? wrappedConnection.unwrap(ConnectionImpl.class)
+                : ((ConnectionImpl) wrappedConnection);
 
             if (conn == null) {
                 try {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ServerAffinityStrategy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ServerAffinityStrategy.java
@@ -59,9 +59,9 @@ public class ServerAffinityStrategy extends RandomBalanceStrategy {
         for (String host : this.affinityOrderedServers) {
             if (configuredHosts.contains(host) && !blockList.containsKey(host)) {
                 final JdbcConnection wrappedConnection = liveConnections.get(host);
-                ConnectionImpl conn = wrappedConnection instanceof ConnectionImpl
-                    ? ((ConnectionImpl) wrappedConnection)
-                    : wrappedConnection.unwrap(ConnectionImpl.class);
+                ConnectionImpl conn = !(wrappedConnection instanceof ConnectionImpl) && wrappedConnection != null
+                    ? wrappedConnection.unwrap(ConnectionImpl.class)
+                    : ((ConnectionImpl) wrappedConnection);
 
                 if (conn != null) {
                     return conn;

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ServerAffinityStrategy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ServerAffinityStrategy.java
@@ -58,7 +58,11 @@ public class ServerAffinityStrategy extends RandomBalanceStrategy {
 
         for (String host : this.affinityOrderedServers) {
             if (configuredHosts.contains(host) && !blockList.containsKey(host)) {
-                ConnectionImpl conn = (ConnectionImpl) liveConnections.get(host);
+                final JdbcConnection wrappedConnection = liveConnections.get(host);
+                ConnectionImpl conn = wrappedConnection instanceof ConnectionImpl
+                    ? ((ConnectionImpl) wrappedConnection)
+                    : wrappedConnection.unwrap(ConnectionImpl.class);
+
                 if (conn != null) {
                     return conn;
                 }


### PR DESCRIPTION
### Summary

The driver sometimes wrap the JdbcConnection object into a proxy. Some methods will attempt to explicitly cast the JdbcConnection object into a MySQL ConnectionImpl object. This will throw a ClassCastException.

### Description

For all JDBC methods that pass in a JdbcConnection as a parameter, check if the object can be casted into a ConnectionImpl object directly, if not, use `unwrap` instead of cast.

### Additional Reviewers

@joyc-bq @aaronchung-bitquill @brunos-bq