### PR TITLE
fix: AWSSecretsManagerPlugin to update ConnectionProxy HostInfo on openInitialConnection (#361)

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ConnectionProxy.java
@@ -169,7 +169,7 @@ public class ConnectionProxy implements ICurrentConnectionProvider, InvocationHa
   @Override
   public void setCurrentConnection(JdbcConnection connection, HostInfo info) {
     try {
-      if (this.currentConnection != null && !this.currentConnection.isClosed()) {
+      if (this.currentConnection != null && !this.currentConnection.equals(connection)  && !this.currentConnection.isClosed()) {
         this.currentConnection.close();
       }
     } catch (SQLException sqlEx) {


### PR DESCRIPTION
### Summary

fix: AWSSecretsManagerPlugin to update ConnectionProxy HostInfo on openInitialConnection (#361)

### Description

Plugins use the currentHostInfo from ConnectionProxy to create connections. Unfortunately, it doesnt get updated with credentials by AWSSecretsManagerPlugin, so connections made this way result in access denials. 

Changed AWSSecretsManagerPlugin to update the currentHostInfo of the CurrentConnectionProvider with user/password so that subsequent plugins that use for creating connections won't get "access denied". 

After talking with @sergiyv-improving , also disabled the code in FailoverConnectionPlugin in attemptConnectionUsingCachedTopology() method as it does not work with the AWSSecretsManagerPlugin, and has no proven improved performance benefits. 

### Additional Reviewers

@sergiyv-improving @karenc-bq @aaron-congo @joyc-bq @brunos-bq