### PR TITLE
refactor: reduce map lookups to reduce number of locks required

### DIFF
--- a/src/main/core-api/java/com/mysql/cj/util/Util.java
+++ b/src/main/core-api/java/com/mysql/cj/util/Util.java
@@ -307,8 +307,9 @@ public class Util {
      * @return boolean
      */
     public static boolean isJdbcInterface(Class<?> clazz) {
-        if (Util.isJdbcInterfaceCache.containsKey(clazz)) {
-            return (Util.isJdbcInterfaceCache.get(clazz));
+        final Boolean isJdbcInterface = Util.isJdbcInterfaceCache.get(clazz);
+        if (isJdbcInterface != null) {
+            return isJdbcInterface;
         }
 
         if (clazz.isInterface()) {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
@@ -61,6 +61,7 @@ import javax.net.ssl.SSLException;
 import java.io.EOFException;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -95,22 +96,26 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
   static final String METHOD_CLOSE = "close";
   static final String METHOD_IS_CLOSED = "isClosed";
 
-  private final static Set<String> METHODS_REQUIRE_UPDATED_TOPOLOGY = new ConcurrentHashMap<String, String>() {{
-    put(METHOD_COMMIT, METHOD_COMMIT);
-    put("connect", "connect");
-    put("isValid", "isValid");
-    put("rollback", "rollback");
-    put("setAutoCommit", "setAutoCommit");
-    put("setReadOnly", "setReadOnly");
-    put("execute", "execute");
-    put("executeBatch", "executeBatch");
-    put("executeLargeBatch", "executeLargeBatch");
-    put("executeLargeUpdate", "executeLargeUpdate");
-    put("executeQuery", "executeQuery");
-    put("executeUpdate", "executeUpdate");
-    put("executeWithFlags", "executeWithFlags");
-    put("getParameterMetaData", "getParameterMetaData");
-  }}.newKeySet();
+  private final static Set<String> METHODS_REQUIRE_UPDATED_TOPOLOGY = ConcurrentHashMap.newKeySet();
+
+  static {
+    METHODS_REQUIRE_UPDATED_TOPOLOGY.addAll(Arrays.asList(
+        METHOD_COMMIT,
+        "connect",
+        "isValid",
+        "rollback",
+        "setAutoCommit",
+        "setReadOnly",
+        "execute",
+        "executeBatch",
+        "executeLargeBatch",
+        "executeLargeUpdate",
+        "executeQuery",
+        "executeUpdate",
+        "executeWithFlags",
+        "getParameterMetaData"
+    ));
+  }
 
   private static final String METHOD_GET_TRANSACTION_ISOLATION =
       "getTransactionIsolation";

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
@@ -61,16 +61,19 @@ import javax.net.ssl.SSLException;
 import java.io.EOFException;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A {@link IConnectionPlugin} implementation that provides cluster-aware failover
@@ -92,22 +95,22 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
   static final String METHOD_CLOSE = "close";
   static final String METHOD_IS_CLOSED = "isClosed";
 
-  private static final List<String> METHODS_REQUIRE_UPDATED_TOPOLOGY = new ArrayList<>(Arrays.asList(
-      METHOD_COMMIT,
-      "connect",
-      "isValid",
-      "rollback",
-      "setAutoCommit",
-      "setReadOnly",
-      "execute",
-      "executeBatch",
-      "executeLargeBatch",
-      "executeLargeUpdate",
-      "executeQuery",
-      "executeUpdate",
-      "executeWithFlags",
-      "getParameterMetaData"
-  ));
+  private final static Set<String> METHODS_REQUIRE_UPDATED_TOPOLOGY = new ConcurrentHashMap<String, String>() {{
+    put(METHOD_COMMIT, METHOD_COMMIT);
+    put("connect", "connect");
+    put("isValid", "isValid");
+    put("rollback", "rollback");
+    put("setAutoCommit", "setAutoCommit");
+    put("setReadOnly", "setReadOnly");
+    put("execute", "execute");
+    put("executeBatch", "executeBatch");
+    put("executeLargeBatch", "executeLargeBatch");
+    put("executeLargeUpdate", "executeLargeUpdate");
+    put("executeQuery", "executeQuery");
+    put("executeUpdate", "executeUpdate");
+    put("executeWithFlags", "executeWithFlags");
+    put("getParameterMetaData", "getParameterMetaData");
+  }}.newKeySet();
 
   private static final String METHOD_GET_TRANSACTION_ISOLATION =
       "getTransactionIsolation";


### PR DESCRIPTION
### Summary

Instead of calling `containsKey` then calling `get`, which requires looking up the map twice, simply call get and check the value. This works because the map doesn't store null values.

### Description



### Additional Reviewers

@brunos-bq
@aaronchung-bitquill 