### PR TITLE
fix: unwrap statement if it is not a ClientPreparedStatement

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/PreparedStatementWrapper.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/PreparedStatementWrapper.java
@@ -29,6 +29,7 @@
 
 package com.mysql.cj.jdbc;
 
+import com.mysql.cj.exceptions.CJException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.lang.reflect.Proxy;
@@ -618,7 +619,7 @@ public class PreparedStatementWrapper extends StatementWrapper implements Prepar
                 try {
                     currentStatement = this.wrappedStmt.unwrap(ClientPreparedStatement.class);
                 } catch (SQLException e) {
-                    throw new RuntimeException(e);
+                    throw new CJException(e);
                 }
             }
             buf.append(((PreparedQuery) currentStatement.getQuery()).asSql());
@@ -955,7 +956,7 @@ public class PreparedStatementWrapper extends StatementWrapper implements Prepar
                     try {
                         currentStatement = this.wrappedStmt.unwrap(ClientPreparedStatement.class);
                     } catch (SQLException e) {
-                        throw new RuntimeException(e);
+                        throw new CJException(e);
                     }
                 }
                 return currentStatement.executeLargeUpdate();

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/PreparedStatementWrapper.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/PreparedStatementWrapper.java
@@ -48,6 +48,7 @@ import java.sql.RowId;
 import java.sql.SQLException;
 import java.sql.SQLType;
 import java.sql.SQLXML;
+import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
@@ -610,7 +611,17 @@ public class PreparedStatementWrapper extends StatementWrapper implements Prepar
         StringBuilder buf = new StringBuilder(super.toString());
         if (this.wrappedStmt != null) {
             buf.append(": ");
-            buf.append(((PreparedQuery) ((ClientPreparedStatement) this.wrappedStmt).getQuery()).asSql());
+            ClientPreparedStatement currentStatement;
+            if (this.wrappedStmt instanceof ClientPreparedStatement) {
+                currentStatement = (ClientPreparedStatement) this.wrappedStmt;
+            } else {
+                try {
+                    currentStatement = this.wrappedStmt.unwrap(ClientPreparedStatement.class);
+                } catch (SQLException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            buf.append(((PreparedQuery) currentStatement.getQuery()).asSql());
         }
         return buf.toString();
     }
@@ -937,7 +948,17 @@ public class PreparedStatementWrapper extends StatementWrapper implements Prepar
     public long executeLargeUpdate() throws SQLException {
         try {
             if (this.wrappedStmt != null) {
-                return ((ClientPreparedStatement) this.wrappedStmt).executeLargeUpdate();
+                ClientPreparedStatement currentStatement;
+                if (this.wrappedStmt instanceof ClientPreparedStatement) {
+                    currentStatement = (ClientPreparedStatement) this.wrappedStmt;
+                } else {
+                    try {
+                        currentStatement = this.wrappedStmt.unwrap(ClientPreparedStatement.class);
+                    } catch (SQLException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                return currentStatement.executeLargeUpdate();
             }
 
             throw SQLError.createSQLException(Messages.getString("Statement.AlreadyClosed"), MysqlErrorNumbers.SQL_STATE_ILLEGAL_ARGUMENT,


### PR DESCRIPTION
### Summary

<!--- General summary / title -->
If the driver wraps a Statement in a proxy, it needs to be unwrapped before it can be cast to a ClientPreparedStatement. A class cast exception will be thrown if the statement object isn't unwrapped.

Addresses issue #401

### Description

<!--- Details of what you changed -->
Checks to confirm if a statement is an instance of a ClientPreparedStatement have been added to methods that cast `this.wrapperStmt` to a ClientPreparedStatement inside `PreparedStatementWrapper.java`.

### Additional Reviewers

<!-- Any additional reviewers -->