### PR TITLE
Remove the isMultiWriterCluster flag from the AuroraTopologyService

### DIFF
--- a/src/main/core-api/java/com/mysql/cj/conf/HostInfo.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/HostInfo.java
@@ -31,6 +31,9 @@ package com.mysql.cj.conf;
 
 import static com.mysql.cj.util.StringUtils.isNullOrEmpty;
 
+import com.mysql.cj.jdbc.ha.plugins.failover.TopologyServicePropertyKeys;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -173,6 +176,17 @@ public class HostInfo implements DatabaseUrlContainer {
      */
     public String getProperty(String key) {
         return this.hostProperties.get(key);
+    }
+
+    /**
+     * Returns the last updated time as a LocalDateTime.
+     *
+     * @return the last updated time.
+     */
+    public LocalDateTime getLastUpdatedTime() {
+        DateTimeFormatter formatter =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSS");
+        return LocalDateTime.parse(this.getProperty(TopologyServicePropertyKeys.LAST_UPDATED), formatter);
     }
 
     /**

--- a/src/main/core-api/java/com/mysql/cj/conf/HostInfo.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/HostInfo.java
@@ -31,9 +31,6 @@ package com.mysql.cj.conf;
 
 import static com.mysql.cj.util.StringUtils.isNullOrEmpty;
 
-import com.mysql.cj.jdbc.ha.plugins.failover.TopologyServicePropertyKeys;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -186,17 +183,6 @@ public class HostInfo implements DatabaseUrlContainer {
     public String getDatabase() {
         String database = this.hostProperties.get(PropertyKey.DBNAME.getKeyName());
         return isNullOrEmpty(database) ? "" : database;
-    }
-
-    /**
-     * Returns the last updated time as a LocalDateTime.
-     *
-     * @return the last updated time.
-     */
-    public LocalDateTime getLastUpdatedTime() {
-        DateTimeFormatter formatter =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.[SSSSSSS][SSSSSS][SSSSS][SSSS][SSS][SS][S]]");
-        return LocalDateTime.parse(this.getProperty(TopologyServicePropertyKeys.LAST_UPDATED), formatter);
     }
 
     /**

--- a/src/main/core-api/java/com/mysql/cj/conf/HostInfo.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/HostInfo.java
@@ -31,6 +31,9 @@ package com.mysql.cj.conf;
 
 import static com.mysql.cj.util.StringUtils.isNullOrEmpty;
 
+import com.mysql.cj.jdbc.ha.plugins.failover.TopologyServicePropertyKeys;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -183,6 +186,17 @@ public class HostInfo implements DatabaseUrlContainer {
     public String getDatabase() {
         String database = this.hostProperties.get(PropertyKey.DBNAME.getKeyName());
         return isNullOrEmpty(database) ? "" : database;
+    }
+
+    /**
+     * Returns the last updated time as a LocalDateTime.
+     *
+     * @return the last updated time.
+     */
+    public LocalDateTime getLastUpdatedTime() {
+        DateTimeFormatter formatter =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.[SSSSSSS][SSSSSS][SSSSS][SSSS][SSS][SS][S]]");
+        return LocalDateTime.parse(this.getProperty(TopologyServicePropertyKeys.LAST_UPDATED), formatter);
     }
 
     /**

--- a/src/main/core-api/java/com/mysql/cj/conf/HostInfo.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/HostInfo.java
@@ -32,8 +32,6 @@ package com.mysql.cj.conf;
 import static com.mysql.cj.util.StringUtils.isNullOrEmpty;
 
 import com.mysql.cj.jdbc.ha.plugins.failover.TopologyServicePropertyKeys;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -179,14 +177,12 @@ public class HostInfo implements DatabaseUrlContainer {
     }
 
     /**
-     * Returns the last updated time as a LocalDateTime.
+     * Returns the last updated time as a String.
      *
      * @return the last updated time.
      */
-    public LocalDateTime getLastUpdatedTime() {
-        DateTimeFormatter formatter =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
-        return LocalDateTime.parse(this.getProperty(TopologyServicePropertyKeys.LAST_UPDATED), formatter);
+    public String getLastUpdatedTime() {
+        return this.getProperty(TopologyServicePropertyKeys.LAST_UPDATED);
     }
 
     /**

--- a/src/main/core-api/java/com/mysql/cj/conf/HostInfo.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/HostInfo.java
@@ -185,7 +185,7 @@ public class HostInfo implements DatabaseUrlContainer {
      */
     public LocalDateTime getLastUpdatedTime() {
         DateTimeFormatter formatter =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSS");
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
         return LocalDateTime.parse(this.getProperty(TopologyServicePropertyKeys.LAST_UPDATED), formatter);
     }
 

--- a/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
+++ b/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
@@ -1056,7 +1056,6 @@ ConnectionProperties.useAwsIam=Set to true to use AWS IAM database authenticatio
 AuroraTopologyService.1=[AuroraTopologyService] clusterId=''{0}''
 AuroraTopologyService.2=[AuroraTopologyService] clusterInstance host=''{0}'', port={1,number,#}, database=''{2}''
 AuroraTopologyService.3=[AuroraTopologyService] The topology query returned an invalid topology - no writer instance detected.
-AuroraTopologyService.4=[AuroraTopologyService] The topology query returned an invalid topology - multi-writer is not supported.
 
 ClusterAwareConnectionProxy.1=Transaction resolution unknown. Please re-configure session state if required and try restarting transaction.
 ClusterAwareConnectionProxy.2=Unable to establish SQL connection to writer node.

--- a/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
+++ b/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
@@ -1055,7 +1055,8 @@ ConnectionProperties.useAwsIam=Set to true to use AWS IAM database authenticatio
 
 AuroraTopologyService.1=[AuroraTopologyService] clusterId=''{0}''
 AuroraTopologyService.2=[AuroraTopologyService] clusterInstance host=''{0}'', port={1,number,#}, database=''{2}''
-AuroraTopologyService.3=[AuroraTopologyService] The topology query returned an invalid topology - no writer instance detected
+AuroraTopologyService.3=[AuroraTopologyService] The topology query returned an invalid topology - no writer instance detected.
+AuroraTopologyService.4=[AuroraTopologyService] The topology query returned an invalid topology - multi-writer is not supported.
 
 ClusterAwareConnectionProxy.1=Transaction resolution unknown. Please re-configure session state if required and try restarting transaction.
 ClusterAwareConnectionProxy.2=Unable to establish SQL connection to writer node.

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
@@ -76,10 +76,7 @@ public class AuroraTopologyService implements ITopologyService {
 
   private long refreshRateNanos;
   static final String RETRIEVE_TOPOLOGY_SQL =
-      "SELECT SERVER_ID, "
-          + "SESSION_ID, "
-          + "DATE_FORMAT(LAST_UPDATE_TIMESTAMP, '%Y-%m-%d %H:%i:%s.%f') AS LAST_UPDATE_TIMESTAMP, "
-          + "REPLICA_LAG_IN_MILLISECONDS "
+      "SELECT SERVER_ID, SESSION_ID, LAST_UPDATE_TIMESTAMP, REPLICA_LAG_IN_MILLISECONDS "
           + "FROM information_schema.replica_host_status "
           + "WHERE time_to_sec(timediff(now(), LAST_UPDATE_TIMESTAMP)) <= 300 " // 5 min
           + "ORDER BY LAST_UPDATE_TIMESTAMP DESC";

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
@@ -49,6 +49,7 @@ import java.sql.SQLSyntaxErrorException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -75,7 +76,10 @@ public class AuroraTopologyService implements ITopologyService {
 
   private long refreshRateNanos;
   static final String RETRIEVE_TOPOLOGY_SQL =
-      "SELECT SERVER_ID, SESSION_ID, LAST_UPDATE_TIMESTAMP, REPLICA_LAG_IN_MILLISECONDS "
+      "SELECT SERVER_ID, "
+          + "SESSION_ID, "
+          + "DATE_FORMAT(LAST_UPDATE_TIMESTAMP, '%Y-%m-%d %H:%i:%s.%f') AS LAST_UPDATE_TIMESTAMP, "
+          + "REPLICA_LAG_IN_MILLISECONDS "
           + "FROM information_schema.replica_host_status "
           + "WHERE time_to_sec(timediff(now(), LAST_UPDATE_TIMESTAMP)) <= 300 " // 5 min
           + "ORDER BY LAST_UPDATE_TIMESTAMP DESC";
@@ -351,7 +355,8 @@ public class AuroraTopologyService implements ITopologyService {
   }
 
   private String convertTimestampToString(Timestamp timestamp) {
-    return timestamp == null ? null : timestamp.toString();
+    DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+    return timestamp == null ? null : formatter.format(timestamp.toLocalDateTime());
   }
 
   /**

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
@@ -75,10 +75,7 @@ public class AuroraTopologyService implements ITopologyService {
 
   private long refreshRateNanos;
   static final String RETRIEVE_TOPOLOGY_SQL =
-      "SELECT SERVER_ID, " +
-          "SESSION_ID, " +
-          "DATE_FORMAT(LAST_UPDATE_TIMESTAMP, '%Y-%m-%d %H:%i:%s.%f') AS LAST_UPDATE_TIMESTAMP, " +
-          "REPLICA_LAG_IN_MILLISECONDS "
+      "SELECT SERVER_ID, SESSION_ID, LAST_UPDATE_TIMESTAMP, REPLICA_LAG_IN_MILLISECONDS "
           + "FROM information_schema.replica_host_status "
           + "WHERE time_to_sec(timediff(now(), LAST_UPDATE_TIMESTAMP)) <= 300 " // 5 min
           + "ORDER BY LAST_UPDATE_TIMESTAMP DESC";

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
@@ -272,10 +272,12 @@ public class AuroraTopologyService implements ITopologyService {
       writers.add(currentHost);
     }
 
-    if (writers.size() == 0) {
+    int writersCount = writers.size();
+
+    if (writersCount == 0) {
       this.log.logError(Messages.getString("AuroraTopologyService.3"));
       hosts.clear();
-    } if (writers.size() == 1) {
+    } else if (writersCount == 1) {
       hosts.add(FailoverConnectionPlugin.WRITER_CONNECTION_INDEX, writers.get(0));
     } else {
       // Store the first writer to its expected position [0]. If there are other writers or stale records, ignore them.

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
@@ -293,7 +293,6 @@ public class AuroraTopologyService implements ITopologyService {
         // If there is more than one writer candidate left, the topology is invalid.
         if (writers.size() == 1) {
           hosts.add(FailoverConnectionPlugin.WRITER_CONNECTION_INDEX, writers.get(0));
-          return new ClusterTopologyInfo(hosts);
         } else {
           hosts.clear();
         }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
@@ -176,7 +176,7 @@ public class AuroraTopologyService implements ITopologyService {
    * @param forceUpdate If true, it forces a service to ignore cached copy of topology and to fetch
    *     a fresh one.
    * @return A list of hosts that describes cluster topology. A writer is always at position 0.
-   *     Returns an empty list if topology isn't available or is invalid (doesn't contain a writer or multi writer).
+   *     Returns an empty list if topology isn't available or is invalid (doesn't contain a writer or is multi writer).
    */
   @Override
   public List<HostInfo> getTopology(JdbcConnection conn, boolean forceUpdate)

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
@@ -147,7 +147,6 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
   protected boolean inTransaction = false;
   protected boolean explicitlyAutoCommit = true;
   protected boolean isClusterTopologyAvailable = false;
-  protected boolean isMultiWriterCluster = false;
   protected boolean isRdsProxy = false;
   protected boolean isRds = false;
   protected ITopologyService topologyService;
@@ -307,7 +306,6 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
     return this.enableFailoverSetting
         && !this.isRdsProxy
         && this.isClusterTopologyAvailable
-        && !this.isMultiWriterCluster
         && (this.hosts == null || this.hosts.size() > 1);
   }
 
@@ -652,8 +650,7 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
 
     if (!this.enableFailoverSetting
         || this.isRdsProxy
-        || !this.isClusterTopologyAvailable
-        || this.isMultiWriterCluster) {
+        || !this.isClusterTopologyAvailable) {
       if (this.logger.isDebugEnabled()) {
         this.logger.logDebug(Messages.getString("ClusterAwareConnectionProxy.13"));
       }
@@ -1057,7 +1054,6 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
                       new Object[]{"isClusterTopologyAvailable",
                               this.isClusterTopologyAvailable}));
     }
-    this.isMultiWriterCluster = this.topologyService.isMultiWriterCluster();
     this.currentHostIndex =
             getHostIndex(topologyService.getHostByName(this.currentConnectionProvider.getCurrentConnection()));
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/ITopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/ITopologyService.java
@@ -141,13 +141,6 @@ public interface ITopologyService {
   void removeFromDownHostList(HostInfo host);
 
   /**
-   * Check if topology belongs to multi-writer cluster.
-   *
-   * @return True, if it's multi-writer cluster.
-   */
-  boolean isMultiWriterCluster();
-
-  /**
    * Set new topology refresh rate. Topology is considered valid (up to date) within provided
    * duration of time.
    *

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyServiceTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyServiceTest.java
@@ -152,13 +152,13 @@ public class AuroraTopologyServiceTest {
     final List<HostInfo> replicas =
         topology.subList(FailoverConnectionPlugin.WRITER_CONNECTION_INDEX + 1, topology.size());
 
-    assertEquals("writer-instance-1.XYZ.us-east-2.rds.amazonaws.com", master.getHost());
+    assertEquals("replica-instance-2.XYZ.us-east-2.rds.amazonaws.com", master.getHost());
     assertEquals(1234, master.getPort());
     assertNull(master.getUser());
     assertNull(master.getPassword());
 
     final Map<String, String> props = master.getHostProperties();
-    assertEquals("writer-instance-1", props.get(TopologyServicePropertyKeys.INSTANCE_NAME));
+    assertEquals("replica-instance-2", props.get(TopologyServicePropertyKeys.INSTANCE_NAME));
     assertEquals(AuroraTopologyService.WRITER_SESSION_ID, props.get(TopologyServicePropertyKeys.SESSION_ID));
     assertEquals("2020-09-15 17:51:53.0", props.get(TopologyServicePropertyKeys.LAST_UPDATED));
     assertEquals("13.5", props.get(TopologyServicePropertyKeys.REPLICA_LAG));
@@ -255,8 +255,8 @@ public class AuroraTopologyServiceTest {
             "replica-instance-1",
             "writer-instance",
             "writer-instance",
-            "writer-instance-1",
-            "writer-instance-1");
+            "replica-instance-2",
+            "replica-instance-2");
     when(results.getTimestamp(AuroraTopologyService.FIELD_LAST_UPDATED))
         .thenReturn(Timestamp.valueOf("2020-09-15 17:51:53.0"));
     when(results.getDouble(AuroraTopologyService.FIELD_REPLICA_LAG)).thenReturn(13.5);

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyServiceTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyServiceTest.java
@@ -32,10 +32,8 @@
 package com.mysql.cj.jdbc.ha.plugins.failover;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -112,7 +110,7 @@ public class AuroraTopologyServiceTest {
     final Map<String, String> props = master.getHostProperties();
     assertEquals("writer-instance", props.get(TopologyServicePropertyKeys.INSTANCE_NAME));
     assertEquals(AuroraTopologyService.WRITER_SESSION_ID, props.get(TopologyServicePropertyKeys.SESSION_ID));
-    assertEquals("2020-09-15 17:51:53.0", props.get(TopologyServicePropertyKeys.LAST_UPDATED));
+    assertEquals(Timestamp.valueOf("2020-09-15 17:51:53.0"), Timestamp.valueOf(props.get(TopologyServicePropertyKeys.LAST_UPDATED)));
     assertEquals("13.5", props.get(TopologyServicePropertyKeys.REPLICA_LAG));
 
     assertEquals(3, topology.size());
@@ -155,7 +153,7 @@ public class AuroraTopologyServiceTest {
     final Map<String, String> props = master.getHostProperties();
     assertEquals("writer-instance-2", props.get(TopologyServicePropertyKeys.INSTANCE_NAME));
     assertEquals(AuroraTopologyService.WRITER_SESSION_ID, props.get(TopologyServicePropertyKeys.SESSION_ID));
-    assertEquals("2020-09-15 17:51:53.123", props.get(TopologyServicePropertyKeys.LAST_UPDATED));
+    assertEquals(Timestamp.valueOf("2020-09-15 17:51:53.123123"), Timestamp.valueOf(props.get(TopologyServicePropertyKeys.LAST_UPDATED)));
     assertEquals("13.5", props.get(TopologyServicePropertyKeys.REPLICA_LAG));
 
     assertEquals(2, topology.size());
@@ -229,12 +227,12 @@ public class AuroraTopologyServiceTest {
             "replica-instance-1");
     when(results.getTimestamp(AuroraTopologyService.FIELD_LAST_UPDATED))
         .thenReturn(
-            Timestamp.valueOf("2020-09-15 17:51:53.123"),
-            Timestamp.valueOf("2020-09-15 17:51:53.123"),
-            Timestamp.valueOf("2020-09-15 17:51:53.0"),
-            Timestamp.valueOf("2020-09-15 17:51:53.0"),
-            Timestamp.valueOf("2020-09-15 17:51:53.456"),
-            Timestamp.valueOf("2020-09-15 17:51:53.456"));
+            Timestamp.valueOf("2020-09-15 17:51:53.123123"),
+            Timestamp.valueOf("2020-09-15 17:51:53.123123"),
+            Timestamp.valueOf("2020-09-15 17:51:53.111111"),
+            Timestamp.valueOf("2020-09-15 17:51:53.111111"),
+            Timestamp.valueOf("2020-09-15 17:51:53.456456"),
+            Timestamp.valueOf("2020-09-15 17:51:53.456456"));
     when(results.getDouble(AuroraTopologyService.FIELD_REPLICA_LAG)).thenReturn(13.5);
   }
 

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyServiceTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyServiceTest.java
@@ -46,6 +46,8 @@ import com.mysql.cj.jdbc.JdbcConnection;
 import com.mysql.cj.jdbc.StatementImpl;
 import com.mysql.cj.jdbc.result.ResultSetImpl;
 import com.mysql.cj.log.Log;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -65,6 +67,7 @@ import java.util.UUID;
 public class AuroraTopologyServiceTest {
 
   private final AuroraTopologyService spyProvider = Mockito.spy(new AuroraTopologyService(Mockito.mock(Log.class)));
+  private final DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
   @BeforeEach
   void resetProvider() {
@@ -110,7 +113,9 @@ public class AuroraTopologyServiceTest {
     final Map<String, String> props = master.getHostProperties();
     assertEquals("writer-instance", props.get(TopologyServicePropertyKeys.INSTANCE_NAME));
     assertEquals(AuroraTopologyService.WRITER_SESSION_ID, props.get(TopologyServicePropertyKeys.SESSION_ID));
-    assertEquals(Timestamp.valueOf("2020-09-15 17:51:53.0"), Timestamp.valueOf(props.get(TopologyServicePropertyKeys.LAST_UPDATED)));
+    assertEquals(
+        Timestamp.valueOf("2020-09-15 17:51:53.0"),
+        Timestamp.valueOf(LocalDateTime.from(formatter.parse(props.get(TopologyServicePropertyKeys.LAST_UPDATED)))));
     assertEquals("13.5", props.get(TopologyServicePropertyKeys.REPLICA_LAG));
 
     assertEquals(3, topology.size());
@@ -153,7 +158,9 @@ public class AuroraTopologyServiceTest {
     final Map<String, String> props = master.getHostProperties();
     assertEquals("writer-instance-2", props.get(TopologyServicePropertyKeys.INSTANCE_NAME));
     assertEquals(AuroraTopologyService.WRITER_SESSION_ID, props.get(TopologyServicePropertyKeys.SESSION_ID));
-    assertEquals(Timestamp.valueOf("2020-09-15 17:51:53.123123"), Timestamp.valueOf(props.get(TopologyServicePropertyKeys.LAST_UPDATED)));
+    assertEquals(
+        Timestamp.valueOf("2020-09-15 17:51:53.123123"),
+        Timestamp.valueOf(LocalDateTime.from(formatter.parse(props.get(TopologyServicePropertyKeys.LAST_UPDATED)))));
     assertEquals("13.5", props.get(TopologyServicePropertyKeys.REPLICA_LAG));
 
     assertEquals(2, topology.size());
@@ -512,7 +519,7 @@ public class AuroraTopologyServiceTest {
 
     final Map<String, String> props = master.getHostProperties();
     // Expected and actual lastUpdated timestamp are rounded since mocking the lastUpdated timestamp is difficult
-    final String expectedLastUpdatedTimeStampRounded = Timestamp.from(Instant.now()).toString().substring(0,16);
+    final String expectedLastUpdatedTimeStampRounded = formatter.format(Timestamp.from(Instant.now()).toLocalDateTime()).substring(0,16);
     final String actualLastUpdatedTimeStampRounded = props.get(TopologyServicePropertyKeys.LAST_UPDATED).substring(0,16);
     assertEquals(expectedLastUpdatedTimeStampRounded, actualLastUpdatedTimeStampRounded);
   }


### PR DESCRIPTION
### Summary

Remove the isMultiWriterCluster flag from the AuroraTopologyService

### Description

Multi writer clusters are not longer supported, so the isMultiWriterCluster flag that was used to disable failover has been removed. Additionally, checks have been added to ensure stale writer records that are obtained post writer-failover are not being used.

### Additional Reviewers

<!-- Any additional reviewers -->