### PR TITLE
refactor: remove host properties from topology

### DIFF
--- a/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
+++ b/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
@@ -1054,7 +1054,7 @@ ConnectionProperties.monitorDisposalTime=Interval in milliseconds for a monitor 
 ConnectionProperties.useAwsIam=Set to true to use AWS IAM database authentication.
 
 AuroraTopologyService.1=[AuroraTopologyService] clusterId=''{0}''
-AuroraTopologyService.2=[AuroraTopologyService] clusterInstance host=''{0}'', port={1,number,#}, database=''{2}''
+AuroraTopologyService.2=[AuroraTopologyService] clusterInstance host=''{0}'', port={1,number,#}
 AuroraTopologyService.3=[AuroraTopologyService] The topology query returned an invalid topology - no writer instance detected.
 
 ClusterAwareConnectionProxy.1=Transaction resolution unknown. Please re-configure session state if required and try restarting transaction.

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ConnectionUtils.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ConnectionUtils.java
@@ -109,11 +109,11 @@ public class ConnectionUtils {
   public static HostInfo copyWithAdditionalProps(
       HostInfo baseHostInfo,
       HostInfo newHostInfo) {
-    DatabaseUrlContainer urlContainer = ConnectionUrl.getConnectionUrlInstance(
+    final DatabaseUrlContainer urlContainer = ConnectionUrl.getConnectionUrlInstance(
         baseHostInfo.getDatabaseUrl(),
         new Properties());
-    Map<String, String> originalProps = baseHostInfo.getHostProperties();
-    Map<String, String> mergedProps = new HashMap<>();
+    final Map<String, String> originalProps = baseHostInfo.getHostProperties();
+    final Map<String, String> mergedProps = new HashMap<>();
     mergedProps.putAll(originalProps);
     mergedProps.putAll(newHostInfo.getHostProperties());
 
@@ -123,16 +123,16 @@ public class ConnectionUtils {
   }
 
   public static HostInfo createHostWithProperties(HostInfo baseHost, Map<String, String> properties) {
-    Map<String, String> propertiesCopy = new HashMap<>(properties);
+    final Map<String, String> propertiesCopy = new HashMap<>(properties);
     propertiesCopy.putAll(baseHost.getHostProperties());
-    String hostEndpoint = baseHost.getHost();
-    int port = baseHost.getPort();
-    String user = propertiesCopy.get(PropertyKey.USER.getKeyName());
-    String password = propertiesCopy.get(PropertyKey.PASSWORD.getKeyName());
+    final String hostEndpoint = baseHost.getHost();
+    final int port = baseHost.getPort();
+    final String user = propertiesCopy.get(PropertyKey.USER.getKeyName());
+    final String password = propertiesCopy.get(PropertyKey.PASSWORD.getKeyName());
     propertiesCopy.remove(PropertyKey.USER.getKeyName());
     propertiesCopy.remove(PropertyKey.PASSWORD.getKeyName());
 
-    ConnectionUrl hostUrl = ConnectionUrl.getConnectionUrlInstance(
+    final ConnectionUrl hostUrl = ConnectionUrl.getConnectionUrlInstance(
         getUrlFromEndpoint(
             hostEndpoint,
             port),
@@ -145,16 +145,6 @@ public class ConnectionUtils {
         user,
         password,
         propertiesCopy);
-  }
-
-  public static List<HostInfo> createTopologyFromSimpleHosts(List<HostInfo> basicTopology, Map<String, String> properties) {
-    List<HostInfo> topology = new ArrayList<>();
-    if (basicTopology != null) {
-      for (HostInfo host : basicTopology) {
-        topology.add(createHostWithProperties(host, properties));
-      }
-    }
-    return topology;
   }
 
   private static String getUrlFromEndpoint(String endpoint, int port) {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
@@ -32,7 +32,6 @@
 package com.mysql.cj.jdbc.ha.plugins.failover;
 
 import com.mysql.cj.Messages;
-import com.mysql.cj.conf.ConnectionUrl;
 import com.mysql.cj.conf.HostInfo;
 import com.mysql.cj.conf.PropertyKey;
 import com.mysql.cj.conf.PropertySet;
@@ -55,7 +54,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -288,17 +286,12 @@ public class AuroraTopologyService implements ITopologyService {
 
   private HostInfo createHost(ResultSet resultSet) throws SQLException {
     String hostEndpoint = getHostEndpoint(resultSet.getString(FIELD_SERVER_ID));
-    ConnectionUrl hostUrl = ConnectionUrl.getConnectionUrlInstance(
-        getUrlFromEndpoint(
-            hostEndpoint,
-            this.clusterInstanceTemplate.getPort()),
-        new Properties());
     return new HostInfo(
-        hostUrl,
+        null,
         hostEndpoint,
         this.clusterInstanceTemplate.getPort(),
-        this.clusterInstanceTemplate.getUser(),
-        this.clusterInstanceTemplate.getPassword(),
+        null,
+        null,
         getPropertiesFromTopology(resultSet));
   }
 
@@ -311,14 +304,6 @@ public class AuroraTopologyService implements ITopologyService {
   private String getHostEndpoint(String nodeName) {
     String host = this.clusterInstanceTemplate.getHost();
     return host.replace("?", nodeName);
-  }
-
-  private String getUrlFromEndpoint(String endpoint, int port) {
-    return String.format(
-        "%s//%s:%d/",
-        ConnectionUrl.Type.SINGLE_CONNECTION_AWS.getScheme(),
-        endpoint,
-        port);
   }
 
   private Map<String, String> getPropertiesFromTopology(ResultSet resultSet)

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
@@ -165,8 +165,7 @@ public class AuroraTopologyService implements ITopologyService {
     this.log.logTrace(Messages.getString(
         "AuroraTopologyService.2",
         new Object[] {clusterInstanceTemplate.getHost(),
-            clusterInstanceTemplate.getPort(),
-            clusterInstanceTemplate.getDatabase()}));
+            clusterInstanceTemplate.getPort()}));
     this.clusterInstanceTemplate = clusterInstanceTemplate;
   }
 
@@ -292,8 +291,7 @@ public class AuroraTopologyService implements ITopologyService {
     ConnectionUrl hostUrl = ConnectionUrl.getConnectionUrlInstance(
         getUrlFromEndpoint(
             hostEndpoint,
-            this.clusterInstanceTemplate.getPort(),
-            this.clusterInstanceTemplate.getDatabase()),
+            this.clusterInstanceTemplate.getPort()),
         new Properties());
     return new HostInfo(
         hostUrl,
@@ -315,19 +313,18 @@ public class AuroraTopologyService implements ITopologyService {
     return host.replace("?", nodeName);
   }
 
-  private String getUrlFromEndpoint(String endpoint, int port, String dbname) {
+  private String getUrlFromEndpoint(String endpoint, int port) {
     return String.format(
-        "%s//%s:%d/%s",
+        "%s//%s:%d/",
         ConnectionUrl.Type.SINGLE_CONNECTION_AWS.getScheme(),
         endpoint,
-        port,
-        dbname);
+        port);
   }
 
   private Map<String, String> getPropertiesFromTopology(ResultSet resultSet)
       throws SQLException {
     Map<String, String> properties =
-        new HashMap<>(this.clusterInstanceTemplate.getHostProperties());
+        new HashMap<>();
     properties.put(
         TopologyServicePropertyKeys.INSTANCE_NAME,
         resultSet.getString(FIELD_SERVER_ID));
@@ -493,7 +490,7 @@ public class AuroraTopologyService implements ITopologyService {
     lastUsedReaderCache.remove(this.clusterId);
   }
 
-  private static class ClusterTopologyInfo {
+  static class ClusterTopologyInfo {
     private List<HostInfo> hosts;
 
     ClusterTopologyInfo(List<HostInfo> hosts) {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareReaderFailoverHandler.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareReaderFailoverHandler.java
@@ -193,9 +193,7 @@ public class ClusterAwareReaderFailoverHandler implements IReaderFailoverHandler
 
             // need to ensure that the new connection is a connection to a reader node
             final HostInfo newHost = hosts.get(result.getConnectionIndex());
-            final List<HostInfo> topology = ConnectionUtils.createTopologyFromSimpleHosts(
-                this.topologyService.getTopology(result.getConnection(), true),
-                this.initialConnectionProps);
+            final List<HostInfo> topology = this.topologyService.getTopology(result.getConnection(), true);
             for (int i = FailoverConnectionPlugin.WRITER_CONNECTION_INDEX + 1; i < topology.size(); i++) {
               if (topology.get(i).equalHostPortPair(newHost)) {
                 return result;
@@ -465,7 +463,8 @@ public class ClusterAwareReaderFailoverHandler implements IReaderFailoverHandler
               new Object[] {this.newHostTuple.getIndex(), newHost.getHostPortPair()}));
 
       try {
-        JdbcConnection conn = connProvider.connect(newHost);
+        HostInfo newHostWithProps = ConnectionUtils.createHostWithProperties(newHost, initialConnectionProps);
+        JdbcConnection conn = connProvider.connect(newHostWithProps);
         topologyService.removeFromDownHostList(newHost);
         log.logDebug(
             Messages.getString(

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareReaderFailoverHandler.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareReaderFailoverHandler.java
@@ -193,7 +193,9 @@ public class ClusterAwareReaderFailoverHandler implements IReaderFailoverHandler
 
             // need to ensure that the new connection is a connection to a reader node
             final HostInfo newHost = hosts.get(result.getConnectionIndex());
-            final List<HostInfo> topology = this.topologyService.getTopology(result.getConnection(), true);
+            final List<HostInfo> topology = ConnectionUtils.createTopologyFromSimpleHosts(
+                this.topologyService.getTopology(result.getConnection(), true),
+                this.initialConnectionProps);
             for (int i = FailoverConnectionPlugin.WRITER_CONNECTION_INDEX + 1; i < topology.size(); i++) {
               if (topology.get(i).equalHostPortPair(newHost)) {
                 return result;
@@ -463,9 +465,7 @@ public class ClusterAwareReaderFailoverHandler implements IReaderFailoverHandler
               new Object[] {this.newHostTuple.getIndex(), newHost.getHostPortPair()}));
 
       try {
-        HostInfo newHostWithProps =
-            ConnectionUtils.copyWithAdditionalProps(newHost, initialConnectionProps);
-        JdbcConnection conn = connProvider.connect(newHostWithProps);
+        JdbcConnection conn = connProvider.connect(newHost);
         topologyService.removeFromDownHostList(newHost);
         log.logDebug(
             Messages.getString(

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
@@ -580,8 +580,7 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
     }
 
     if (!Util.isNullOrEmpty(failoverResult.getTopology())) {
-      this.hosts =
-          ConnectionUtils.createTopologyFromSimpleHosts(failoverResult.getTopology(), this.initialConnectionProps);
+      this.hosts = failoverResult.getTopology();
     }
 
     metricsContainer.registerFailoverConnects(true);
@@ -733,9 +732,7 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
       return;
     }
 
-    List<HostInfo> latestTopology = ConnectionUtils.createTopologyFromSimpleHosts(
-        this.topologyService.getTopology(connection, forceUpdate),
-        this.initialConnectionProps);
+    List<HostInfo> latestTopology = this.topologyService.getTopology(connection, forceUpdate);
 
     updateHostIndex(latestTopology);
     this.hosts = latestTopology;
@@ -1019,9 +1016,7 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
 
   private void fetchTopology() throws SQLException {
     final JdbcConnection currentConnection = this.currentConnectionProvider.getCurrentConnection();
-    List<HostInfo> topology = ConnectionUtils.createTopologyFromSimpleHosts(
-        this.topologyService.getTopology(currentConnection, false),
-        this.initialConnectionProps);
+    List<HostInfo> topology = this.topologyService.getTopology(currentConnection, false);
     if (!Util.isNullOrEmpty(topology)) {
       this.hosts = topology;
     }

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareTestUtils.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareTestUtils.java
@@ -45,6 +45,10 @@ import java.util.Properties;
  * {@link ClusterAwareReaderFailoverHandlerTest} and {@link ClusterAwareWriterFailoverHandlerTest}.
  */
 public class ClusterAwareTestUtils {
+  protected static HostInfo createBasicHostInfo(String instanceName) {
+    return createBasicHostInfo(instanceName, null, null, null);
+  }
+
   protected static HostInfo createBasicHostInfo(String instanceName, String db) {
     return createBasicHostInfo(instanceName, db, null, null);
   }
@@ -57,9 +61,10 @@ public class ClusterAwareTestUtils {
     final Map<String, String> properties = new HashMap<>();
     properties.put(TopologyServicePropertyKeys.INSTANCE_NAME, instanceName);
     String url = "jdbc:mysql:aws://" + instanceName + ".com:1234/";
-    db = (db == null) ? "" : db;
-    properties.put(PropertyKey.DBNAME.getKeyName(), db);
-    url += db;
+    if (db != null) {
+      properties.put(PropertyKey.DBNAME.getKeyName(), db);
+      url += db;
+    }
     final ConnectionUrl conStr =
         ConnectionUrl.getConnectionUrlInstance(url, new Properties());
     return new HostInfo(conStr, instanceName, 1234, user, password, properties);

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareTestUtils.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareTestUtils.java
@@ -68,7 +68,6 @@ public class ClusterAwareTestUtils {
     String host = instanceName + ".com";
     if (db != null) {
       properties.put(PropertyKey.DBNAME.getKeyName(), db);
-      url += db;
     }
     final ConnectionUrl conStr =
         ConnectionUrl.getConnectionUrlInstance(url, new Properties());
@@ -85,35 +84,19 @@ public class ClusterAwareTestUtils {
 
     @Override
     public boolean matches(HostInfo host) {
-      return expectedHost.getHost().equals(host.getHost()) &&
-          expectedHost.getDatabase().equals(host.getDatabase()) &&
-          expectedHost.getPort() == host.getPort() &&
-          expectedHost.getDatabaseUrl().equals(host.getDatabaseUrl()) &&
-          expectedHost.getHostProperties().equals(host.getHostProperties());
+      return hostsAreTheSame(expectedHost, host);
     }
   }
 
-    protected static boolean hostsAreTheSame(HostInfo hostInfo1, HostInfo hostInfo2) {
-      if (hostInfo1 == hostInfo2) {
-        return true;
-      }
-
-      boolean sameProperties =
-          hostInfo1.getHostProperties().size() == hostInfo2.getHostProperties().size();
-      for (Map.Entry<String,String> property : hostInfo1.getHostProperties().entrySet()) {
-        if (hostInfo2.getHostProperties().get(property.getKey()) == null ||
-          !Objects.equals(
-              hostInfo2.getHostProperties().get(property.getKey()),
-              hostInfo1.getHostProperties().get(property.getKey()))) {
-          sameProperties = false;
-          break;
-        }
-      }
-
-      return hostInfo1.getPort() == hostInfo2.getPort() &&
-          Objects.equals(hostInfo1.getUser(), hostInfo2.getUser()) &&
-          Objects.equals(hostInfo1.getPassword(), hostInfo2.getPassword()) &&
-          sameProperties &&
-          Objects.equals(hostInfo1.getDatabaseUrl(), hostInfo2.getDatabaseUrl());
+  protected static boolean hostsAreTheSame(HostInfo hostInfo1, HostInfo hostInfo2) {
+    if (hostInfo1 == hostInfo2) {
+      return true;
     }
+
+    return hostInfo1.getPort() == hostInfo2.getPort() &&
+        Objects.equals(hostInfo1.getUser(), hostInfo2.getUser()) &&
+        Objects.equals(hostInfo1.getPassword(), hostInfo2.getPassword()) &&
+        Objects.equals(hostInfo1.exposeAsProperties(), hostInfo2.exposeAsProperties()) &&
+        Objects.equals(hostInfo1.getDatabaseUrl(), hostInfo2.getDatabaseUrl());
+  }
 }

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareWriterFailoverHandlerTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareWriterFailoverHandlerTest.java
@@ -78,9 +78,9 @@ public class ClusterAwareWriterFailoverHandlerTest {
     final ConnectionImpl mockConnection = Mockito.mock(ConnectionImpl.class);
     final IReaderFailoverHandler mockReaderFailover = Mockito.mock(IReaderFailoverHandler.class);
 
-    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host", "test");
-    final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test");
-    final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host", "test");
+    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host");
+    final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host");
+    final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host");
     final List<HostInfo> currentTopology = new ArrayList<>();
     currentTopology.add(writerHost);
     currentTopology.add(readerA_Host);
@@ -133,15 +133,15 @@ public class ClusterAwareWriterFailoverHandlerTest {
     final ConnectionImpl mockReaderA_Connection = Mockito.mock(ConnectionImpl.class);
     final IReaderFailoverHandler mockReaderFailover = Mockito.mock(IReaderFailoverHandler.class);
 
-    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host", "test");
-    final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test");
-    final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host", "test");
+    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host");
+    final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host");
+    final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host");
     final List<HostInfo> currentTopology = new ArrayList<>();
     currentTopology.add(writerHost);
     currentTopology.add(readerA_Host);
     currentTopology.add(readerB_Host);
 
-    final HostInfo newWriterHost = ClusterAwareTestUtils.createBasicHostInfo("new-writer-host", "test");
+    final HostInfo newWriterHost = ClusterAwareTestUtils.createBasicHostInfo("new-writer-host");
     final List<HostInfo> newTopology = new ArrayList<>();
     newTopology.add(newWriterHost);
     newTopology.add(readerA_Host);
@@ -199,9 +199,9 @@ public class ClusterAwareWriterFailoverHandlerTest {
     final ConnectionImpl mockReaderA_Connection = Mockito.mock(ConnectionImpl.class);
     final IReaderFailoverHandler mockReaderFailover = Mockito.mock(IReaderFailoverHandler.class);
 
-    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host", "test");
-    final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test");
-    final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host", "test");
+    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host");
+    final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host");
+    final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host");
     final List<HostInfo> currentTopology = new ArrayList<>();
     currentTopology.add(writerHost);
     currentTopology.add(readerA_Host);
@@ -261,15 +261,15 @@ public class ClusterAwareWriterFailoverHandlerTest {
     final ConnectionImpl mockReaderB_Connection = Mockito.mock(ConnectionImpl.class);
     final IReaderFailoverHandler mockReaderFailover = Mockito.mock(IReaderFailoverHandler.class);
 
-    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host", "test");
-    final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test");
-    final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host", "test");
+    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host");
+    final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host");
+    final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host");
     final List<HostInfo> currentTopology = new ArrayList<>();
     currentTopology.add(writerHost);
     currentTopology.add(readerA_Host);
     currentTopology.add(readerB_Host);
 
-    final HostInfo newWriterHost = ClusterAwareTestUtils.createBasicHostInfo("new-writer-host", "test");
+    final HostInfo newWriterHost = ClusterAwareTestUtils.createBasicHostInfo("new-writer-host");
     final List<HostInfo> newTopology = new ArrayList<>();
     newTopology.add(newWriterHost);
     newTopology.add(readerA_Host);
@@ -332,15 +332,15 @@ public class ClusterAwareWriterFailoverHandlerTest {
     final ConnectionImpl mockReaderB_Connection = Mockito.mock(ConnectionImpl.class);
     final IReaderFailoverHandler mockReaderFailover = Mockito.mock(IReaderFailoverHandler.class);
 
-    final HostInfo initialWriterHost = ClusterAwareTestUtils.createBasicHostInfo("initial-writer-host", "test");
-    final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test");
-    final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host", "test");
+    final HostInfo initialWriterHost = ClusterAwareTestUtils.createBasicHostInfo("initial-writer-host");
+    final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host");
+    final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host");
     final List<HostInfo> currentTopology = new ArrayList<>();
     currentTopology.add(initialWriterHost);
     currentTopology.add(readerA_Host);
     currentTopology.add(readerB_Host);
 
-    final HostInfo newWriterHost = ClusterAwareTestUtils.createBasicHostInfo("new-writer-host", "test");
+    final HostInfo newWriterHost = ClusterAwareTestUtils.createBasicHostInfo("new-writer-host");
     final List<HostInfo> newTopology = new ArrayList<>();
     newTopology.add(newWriterHost);
     newTopology.add(initialWriterHost);
@@ -405,15 +405,15 @@ public class ClusterAwareWriterFailoverHandlerTest {
     final ConnectionImpl mockReaderB_Connection = Mockito.mock(ConnectionImpl.class);
     final IReaderFailoverHandler mockReaderFailover = Mockito.mock(IReaderFailoverHandler.class);
 
-    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host", "test");
-    final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test");
-    final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host", "test");
+    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host");
+    final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host");
+    final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host");
     final List<HostInfo> currentTopology = new ArrayList<>();
     currentTopology.add(writerHost);
     currentTopology.add(readerA_Host);
     currentTopology.add(readerB_Host);
 
-    final HostInfo newWriterHost = ClusterAwareTestUtils.createBasicHostInfo("new-writer-host", "test");
+    final HostInfo newWriterHost = ClusterAwareTestUtils.createBasicHostInfo("new-writer-host");
     final List<HostInfo> newTopology = new ArrayList<>();
     newTopology.add(newWriterHost);
     newTopology.add(readerA_Host);
@@ -477,15 +477,15 @@ public class ClusterAwareWriterFailoverHandlerTest {
     final ConnectionImpl mockReaderB_Connection = Mockito.mock(ConnectionImpl.class);
     final IReaderFailoverHandler mockReaderFailover = Mockito.mock(IReaderFailoverHandler.class);
 
-    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host", "test");
-    final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test");
-    final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host", "test");
+    final HostInfo writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer-host");
+    final HostInfo readerA_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-a-host");
+    final HostInfo readerB_Host = ClusterAwareTestUtils.createBasicHostInfo("reader-b-host");
     final List<HostInfo> currentTopology = new ArrayList<>();
     currentTopology.add(writerHost);
     currentTopology.add(readerA_Host);
     currentTopology.add(readerB_Host);
 
-    final HostInfo newWriterHost = ClusterAwareTestUtils.createBasicHostInfo("new-writer-host", "test");
+    final HostInfo newWriterHost = ClusterAwareTestUtils.createBasicHostInfo("new-writer-host");
     final List<HostInfo> newTopology = new ArrayList<>();
     newTopology.add(newWriterHost);
     newTopology.add(readerA_Host);

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareWriterFailoverHandlerTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/ClusterAwareWriterFailoverHandlerTest.java
@@ -36,9 +36,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -310,7 +313,7 @@ public class ClusterAwareWriterFailoverHandlerTest {
     assertTrue(result.isNewHost());
     assertSame(result.getNewConnection(), mockNewWriterConnection);
     assertEquals(3, result.getTopology().size());
-    assertEquals("new-writer-host", result.getTopology().get(0).getHost());
+    assertEquals("new-writer-host.com", result.getTopology().get(0).getHost());
 
     verify(mockTopologyService, times(1)).addToDownHostList(refEq(writerHost));
     verify(mockTopologyService, times(1)).removeFromDownHostList(refEq(newWriterHost));
@@ -381,7 +384,7 @@ public class ClusterAwareWriterFailoverHandlerTest {
     assertTrue(result.isNewHost());
     assertSame(result.getNewConnection(), mockNewWriterConnection);
     assertEquals(4, result.getTopology().size());
-    assertEquals("new-writer-host", result.getTopology().get(0).getHost());
+    assertEquals("new-writer-host.com", result.getTopology().get(0).getHost());
 
     verify(mockTopologyService, times(1)).addToDownHostList(refEq(initialWriterHost));
     verify(mockTopologyService, times(1)).removeFromDownHostList(refEq(newWriterHost));
@@ -491,10 +494,17 @@ public class ClusterAwareWriterFailoverHandlerTest {
     newTopology.add(readerA_Host);
     newTopology.add(readerB_Host);
 
-    when(mockConnectionProvider.connect(refEq(writerHost))).thenThrow(new SQLException("exception", "08S01", null));
-    when(mockConnectionProvider.connect(refEq(readerA_Host))).thenReturn(mockReaderA_Connection);
-    when(mockConnectionProvider.connect(refEq(readerB_Host))).thenReturn(mockReaderB_Connection);
-    when(mockConnectionProvider.connect(refEq(newWriterHost))).thenThrow(SQLException.class);
+    ClusterAwareTestUtils.HostInfoMatcher writerMatcher = new ClusterAwareTestUtils.HostInfoMatcher(writerHost);
+    ClusterAwareTestUtils.HostInfoMatcher newWriterMatcher = new ClusterAwareTestUtils.HostInfoMatcher(newWriterHost);
+
+    doThrow(new SQLException("exception", "08S01", null))
+        .when(mockConnectionProvider).connect(argThat(writerMatcher));
+    doReturn(mockReaderA_Connection)
+        .when(mockConnectionProvider).connect(argThat(new ClusterAwareTestUtils.HostInfoMatcher(readerA_Host)));
+    doReturn(mockReaderB_Connection)
+        .when(mockConnectionProvider).connect(argThat(new ClusterAwareTestUtils.HostInfoMatcher(readerB_Host)));
+    doThrow(SQLException.class)
+        .when(mockConnectionProvider).connect(argThat(newWriterMatcher));
 
     when(mockTopologyService.getTopology(any(JdbcConnection.class), any(Boolean.class)))
         .thenReturn(newTopology);
@@ -517,7 +527,7 @@ public class ClusterAwareWriterFailoverHandlerTest {
     assertFalse(result.isConnected());
     assertFalse(result.isNewHost());
 
-    verify(mockTopologyService, times(1)).addToDownHostList(refEq(writerHost));
-    verify(mockTopologyService, atLeastOnce()).addToDownHostList(refEq(newWriterHost));
+    verify(mockTopologyService, times(1)).addToDownHostList(argThat(writerMatcher));
+    verify(mockTopologyService, atLeastOnce()).addToDownHostList(argThat(newWriterMatcher));
   }
 }

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPluginTest.java
@@ -40,7 +40,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -56,6 +59,7 @@ import com.mysql.cj.jdbc.ha.plugins.IConnectionPlugin;
 import com.mysql.cj.jdbc.ha.plugins.IConnectionProvider;
 import com.mysql.cj.jdbc.ha.plugins.ICurrentConnectionProvider;
 import com.mysql.cj.log.Log;
+import java.util.Objects;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,9 +80,9 @@ class FailoverConnectionPluginTest {
   private static final int PORT = 1234;
   private static final String DATABASE = "test";
   private final HostInfo writerHost =
-      ClusterAwareTestUtils.createBasicHostInfo("writer", "test");
+      ClusterAwareTestUtils.createBasicHostInfo("writer");
   private final HostInfo readerHost =
-      ClusterAwareTestUtils.createBasicHostInfo("reader", "test");
+      ClusterAwareTestUtils.createBasicHostInfo("reader");
   private final List<HostInfo> mockTopology =
       new ArrayList<>(Arrays.asList(writerHost, readerHost));
   @Mock private ConnectionImpl mockConnection;
@@ -103,11 +107,11 @@ class FailoverConnectionPluginTest {
     when(mockHostInfo.getDatabaseUrl()).thenReturn(url);
     when(mockHostInfo.getHost()).thenReturn(host);
     final HostInfo writerHost =
-        ClusterAwareTestUtils.createBasicHostInfo("writer-host", "test");
+        ClusterAwareTestUtils.createBasicHostInfo("writer-host");
     final HostInfo readerA_Host =
-        ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test");
+        ClusterAwareTestUtils.createBasicHostInfo("reader-a-host");
     final HostInfo readerB_Host =
-        ClusterAwareTestUtils.createBasicHostInfo("reader-b-host", "test");
+        ClusterAwareTestUtils.createBasicHostInfo("reader-b-host");
     final List<HostInfo> topology = new ArrayList<>();
     topology.add(writerHost);
     topology.add(readerA_Host);
@@ -197,11 +201,11 @@ class FailoverConnectionPluginTest {
     when(mockHostInfo.getHost()).thenReturn(host);
 
     final HostInfo writerHost =
-        ClusterAwareTestUtils.createBasicHostInfo("writer-host", null);
+        ClusterAwareTestUtils.createBasicHostInfo("writer-host");
     final HostInfo readerAHost =
-        ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", null);
+        ClusterAwareTestUtils.createBasicHostInfo("reader-a-host");
     final HostInfo readerBHost =
-        ClusterAwareTestUtils.createBasicHostInfo("reader-b-host", null);
+        ClusterAwareTestUtils.createBasicHostInfo("reader-b-host");
     final List<HostInfo> topology = new ArrayList<>();
     topology.add(writerHost);
     topology.add(readerAHost);
@@ -241,20 +245,20 @@ class FailoverConnectionPluginTest {
     when(mockHostInfo.getHost()).thenReturn(host);
 
     final HostInfo cachedWriterHost =
-        ClusterAwareTestUtils.createBasicHostInfo("cached-writer-host", "test");
+        ClusterAwareTestUtils.createBasicHostInfo("cached-writer-host");
     final HostInfo readerA_Host =
-        ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test");
+        ClusterAwareTestUtils.createBasicHostInfo("reader-a-host");
     final HostInfo readerB_Host =
-        ClusterAwareTestUtils.createBasicHostInfo("reader-b-host", "test");
+        ClusterAwareTestUtils.createBasicHostInfo("reader-b-host");
     final List<HostInfo> cachedTopology = new ArrayList<>();
     cachedTopology.add(cachedWriterHost);
     cachedTopology.add(readerA_Host);
     cachedTopology.add(readerB_Host);
 
     final HostInfo actualWriterHost =
-        ClusterAwareTestUtils.createBasicHostInfo("actual-writer-host", "test");
+        ClusterAwareTestUtils.createBasicHostInfo("actual-writer-host");
     final HostInfo obsoleteWriterHost =
-        ClusterAwareTestUtils.createBasicHostInfo("obsolete-writer-host", "test");
+        ClusterAwareTestUtils.createBasicHostInfo("obsolete-writer-host");
     final List<HostInfo> actualTopology = new ArrayList<>();
     actualTopology.add(actualWriterHost);
     actualTopology.add(readerA_Host);
@@ -414,11 +418,11 @@ class FailoverConnectionPluginTest {
     final int newConnectionHostIndex = 1;
 
     final HostInfo writerHost =
-        ClusterAwareTestUtils.createBasicHostInfo("writer-host", "test");
+        ClusterAwareTestUtils.createBasicHostInfo("writer-host");
     final HostInfo readerA_Host =
-        ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test");
+        ClusterAwareTestUtils.createBasicHostInfo("reader-a-host");
     final HostInfo readerB_Host =
-        ClusterAwareTestUtils.createBasicHostInfo("reader-b-host", "test");
+        ClusterAwareTestUtils.createBasicHostInfo("reader-b-host");
     final List<HostInfo> topology = new ArrayList<>();
     topology.add(writerHost);
     topology.add(readerA_Host);
@@ -551,11 +555,11 @@ class FailoverConnectionPluginTest {
     when(mockHostInfo.getHost()).thenReturn(host);
 
     final HostInfo writerHost =
-        ClusterAwareTestUtils.createBasicHostInfo("writer-host", "test");
+        ClusterAwareTestUtils.createBasicHostInfo("writer-host");
     final HostInfo readerA_Host =
-        ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test");
+        ClusterAwareTestUtils.createBasicHostInfo("reader-a-host");
     final HostInfo readerB_Host =
-        ClusterAwareTestUtils.createBasicHostInfo("reader-b-host", "test");
+        ClusterAwareTestUtils.createBasicHostInfo("reader-b-host");
     final List<HostInfo> topology = new ArrayList<>();
     topology.add(writerHost);
     topology.add(readerA_Host);
@@ -585,9 +589,9 @@ class FailoverConnectionPluginTest {
     final int connectionHostIndex = 1;
 
     final HostInfo writerHost =
-        ClusterAwareTestUtils.createBasicHostInfo("writer-host", "test");
+        ClusterAwareTestUtils.createBasicHostInfo("writer-host");
     final HostInfo readerAHost =
-        ClusterAwareTestUtils.createBasicHostInfo("reader-a-host", "test");
+        ClusterAwareTestUtils.createBasicHostInfo("reader-a-host");
     final List<HostInfo> topology = new ArrayList<>();
     topology.add(writerHost);
     topology.add(readerAHost);
@@ -643,6 +647,50 @@ class FailoverConnectionPluginTest {
     assertFalse(failoverPlugin.isFailoverEnabled());
   }
 
+  @Test
+  public void testPluginsShareTopologyCache() throws Exception {
+    final String clusterId = "clusterId";
+    final String url =
+        "jdbc:mysql:aws://my-cluster-name.cluster-ro-XYZ.us-east-2.rds.amazonaws.com";
+    final String host = url.split(PREFIX)[1];
+    when(mockHostInfo.getDatabaseUrl()).thenReturn(url);
+    when(mockHostInfo.getHost()).thenReturn(host);
+
+    final HostInfo writerHost =
+        ClusterAwareTestUtils.createBasicHostInfo("writer-host");
+    final HostInfo readerA_Host =
+        ClusterAwareTestUtils.createBasicHostInfo("reader-a-host");
+    final HostInfo readerB_Host =
+        ClusterAwareTestUtils.createBasicHostInfo("reader-b-host");
+    final List<HostInfo> topology = new ArrayList<>();
+    topology.add(writerHost);
+    topology.add(readerA_Host);
+    topology.add(readerB_Host);
+    AuroraTopologyService auroraTopologyService1 = new AuroraTopologyService(null);
+    AuroraTopologyService spyAuroratopologyService1 = spy(auroraTopologyService1);
+    spyAuroratopologyService1.clusterId = clusterId;
+
+    AuroraTopologyService auroraTopologyService2 = new AuroraTopologyService(null);
+    AuroraTopologyService spyAuroratopologyService2 = spy(auroraTopologyService2);
+    spyAuroratopologyService2.clusterId = clusterId;
+
+    doReturn(new AuroraTopologyService.ClusterTopologyInfo(topology))
+        .when(spyAuroratopologyService1).queryForTopology(eq(mockConnection));
+    doReturn(writerHost).when(spyAuroratopologyService1).getHostByName(eq(mockConnection));
+    doReturn(new AuroraTopologyService.ClusterTopologyInfo(topology))
+        .when(spyAuroratopologyService2).queryForTopology(eq(mockConnection));
+    doReturn(writerHost).when(spyAuroratopologyService2).getHostByName(eq(mockConnection));
+
+    final Properties properties = new Properties();
+    final FailoverConnectionPlugin failoverPlugin1 = initFailoverPlugin(properties, spyAuroratopologyService1);
+    final FailoverConnectionPlugin failoverPlugin2 = initFailoverPlugin(properties, spyAuroratopologyService2);
+
+    assert(Objects.equals(failoverPlugin1.hosts.get(0).getDatabase(), ""));
+    assertEquals(failoverPlugin1.hosts, failoverPlugin2.hosts);
+    verify(spyAuroratopologyService1, times(1)).queryForTopology(eq(mockConnection));
+    verify(spyAuroratopologyService2, never()).queryForTopology(eq(mockConnection));
+  }
+
   @AfterEach
   void cleanUp() throws Exception {
     closeable.close();
@@ -666,10 +714,14 @@ class FailoverConnectionPluginTest {
   }
 
   private FailoverConnectionPlugin initFailoverPlugin() throws SQLException {
-    return initFailoverPlugin(new Properties());
+    return initFailoverPlugin(new Properties(), mockTopologyService);
   }
 
-  private FailoverConnectionPlugin initFailoverPlugin(Properties properties)
+  private FailoverConnectionPlugin initFailoverPlugin(Properties properties) throws SQLException {
+    return initFailoverPlugin(properties, mockTopologyService);
+  }
+  
+  private FailoverConnectionPlugin initFailoverPlugin(Properties properties, AuroraTopologyService topologyService)
       throws SQLException {
     final JdbcPropertySet propertySet = new JdbcPropertySetImpl();
     propertySet.initializeProperties(properties);
@@ -680,7 +732,7 @@ class FailoverConnectionPluginTest {
         mockNextPlugin,
         mockLogger,
         mockConnectionProvider,
-        () -> mockTopologyService,
+        () -> topologyService,
         () -> mockClusterMetricContainer);
   }
 }

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPluginTest.java
@@ -285,9 +285,9 @@ class FailoverConnectionPluginTest {
     assertEquals(
         FailoverConnectionPlugin.WRITER_CONNECTION_INDEX,
         failoverPlugin.currentHostIndex);
-    assertEquals(
+    assertTrue(ClusterAwareTestUtils.hostsAreTheSame(
         actualWriterHost,
-        failoverPlugin.hosts.get(failoverPlugin.currentHostIndex));
+        failoverPlugin.hosts.get(failoverPlugin.currentHostIndex)));
     assertFalse(failoverPlugin.explicitlyReadOnly);
     assertFalse(failoverPlugin.isCurrentConnectionReadOnly());
   }
@@ -620,7 +620,7 @@ class FailoverConnectionPluginTest {
 
     final FailoverConnectionPlugin failoverPlugin = initFailoverPlugin(properties);
 
-    assertEquals(0, failoverPlugin.initialConnectionProps.size());
+    assertEquals(4, failoverPlugin.initialConnectionProps.size());
     assertFalse(failoverPlugin.isRds());
     assertFalse(failoverPlugin.isRdsProxy());
     assertFalse(failoverPlugin.isClusterTopologyAvailable);
@@ -639,7 +639,7 @@ class FailoverConnectionPluginTest {
     final FailoverConnectionPlugin failoverPlugin = initFailoverPlugin(properties);
     final Map<String, String> initialConnectionProperties = failoverPlugin.initialConnectionProps;
 
-    assertEquals(1, initialConnectionProperties.size());
+    assertEquals(5, initialConnectionProperties.size());
     assertEquals("10", initialConnectionProperties.get("maxAllowedPacket"));
     assertFalse(failoverPlugin.isRds());
     assertFalse(failoverPlugin.isRdsProxy());
@@ -686,7 +686,10 @@ class FailoverConnectionPluginTest {
     final FailoverConnectionPlugin failoverPlugin2 = initFailoverPlugin(properties, spyAuroratopologyService2);
 
     assert(Objects.equals(failoverPlugin1.hosts.get(0).getDatabase(), ""));
-    assertEquals(failoverPlugin1.hosts, failoverPlugin2.hosts);
+    assertEquals(failoverPlugin1.hosts.size(), failoverPlugin2.hosts.size());
+    for (int i = 0; i < failoverPlugin1.hosts.size(); i++) {
+      assertTrue(ClusterAwareTestUtils.hostsAreTheSame(failoverPlugin1.hosts.get(i), failoverPlugin2.hosts.get(i)));
+    }
     verify(spyAuroratopologyService1, times(1)).queryForTopology(eq(mockConnection));
     verify(spyAuroratopologyService2, never()).queryForTopology(eq(mockConnection));
   }


### PR DESCRIPTION
### Summary

Remove additional host properties from topology

### Description

When the failover plugin is initialized, it passes properties to the AuroraTopologyService. This means that when the topology service gets a topology, every HostInfo object in the topology will contain the same properties. The topology is stored in a cache, which is identified by the cluster ID. This means different connections to the same cluster may retrieve topology information containing properties of each other.

This PR removes the host properties other than the host and port number from the topology service and instead sets the initialConnectionProps to contain them instead.

Addresses issue #407 

### Additional Reviewers

@YoungHu