### PR TITLE
fix: Accept "convertToNull" value for property "zeroDateTimeBehaviour"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/#semantic-versioning-200).
 
+## [?]
+### Fixed
+- Fixed value `convertToNull` being rejected for property `zeroDateTimeBehavior` because of capitalization ([Issue #411](https://github.com/awslabs/aws-mysql-jdbc/pull/413)).
+
 ## [1.1.7] - 2023-05-11
 ### Changed
 * Removed the `isMultiWriterCluster` flag as [multi-writer clusters are end of life since February 2023](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.MySQL56.EOL.html). ([PR #405](https://github.com/awslabs/aws-mysql-jdbc/pull/405)).

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/ConnectionProxy.java
@@ -54,6 +54,7 @@ import java.lang.reflect.Proxy;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Properties;
 import java.util.function.Function;
 
 /**
@@ -225,7 +226,13 @@ public class ConnectionProxy implements ICurrentConnectionProvider, InvocationHa
 
   protected void initSettings(ConnectionUrl connectionUrl) throws SQLException {
     try {
-      this.connProps.initializeProperties(connectionUrl.getConnectionArgumentsAsProperties());
+      final Properties props = new Properties();
+      for (Map.Entry<String, String> entry : connectionUrl.getMainHost().getHostProperties().entrySet()) {
+        if (entry.getValue() != null) {
+          props.put(entry.getKey(), entry.getValue());
+        }
+      }
+      this.connProps.initializeProperties(props);
     } catch (CJException e) {
       throw SQLExceptionsMapping.translateException(e, null);
     }

--- a/src/test/java/com/mysql/cj/jdbc/ha/ConnectionProxyTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/ConnectionProxyTest.java
@@ -152,6 +152,19 @@ public class ConnectionProxyTest {
     assertSame(mockHostInfo, proxy.getCurrentHostInfo());
   }
 
+  @Test
+  public void testAwsProtocolWithLegacyPropertyValues() throws SQLException {
+    final Properties props = new Properties();
+    props.setProperty("zeroDateTimeBehavior", "convertToNull");
+
+    final ConnectionUrl conStr =
+        ConnectionUrl.getConnectionUrlInstance(DEFAULT_CONNECTION_STR, props);
+    final ConnectionProxy proxy = getConnectionProxy(conStr);
+
+    assertSame(mockConnection, proxy.getCurrentConnection());
+    assert(proxy.getCurrentHostInfo().getHostProperties().get("zeroDateTimeBehavior").equals("CONVERT_TO_NULL"));
+  }
+
   @AfterEach
   void cleanUp() throws Exception {
     closeable.close();


### PR DESCRIPTION
### Summary

Accept "convertToNull" value for property "zeroDateTimeBehaviour"

### Description

Some connection properties such as `zeroDateTimeBehaviour` are altered in the `fixHostInfo` method. The `zeroDateTimeBehaviour` value in particular is replaced in the `replaceLegacyPropertyValues` method. This allows the driver to accept both upper and lowercase values. When the driver detects an AWS JDBC Driver protocol, it will create a proxy using the properties the user specified and not the corrected set. This PR will use the "fixed" properties instead.

### Additional Reviewers

<!-- Any additional reviewers -->