### PR TITLE
fix: handle the case when this.currentHostIndex is an invalid index

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
@@ -1264,6 +1264,11 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
   }
 
   private void updateHostIndex(List<HostInfo> latestTopology) throws SQLException {
+    if (this.currentHostIndex == NO_CONNECTION_INDEX) {
+      pickNewConnection();
+      return;
+    }
+
     HostInfo currentHost = this.hosts.get(this.currentHostIndex);
 
     int latestHostIndex = NO_CONNECTION_INDEX;


### PR DESCRIPTION
### Summary

`updateHostIndex` may throw an IndexOutOfBoundException if `this.currentHostIndex` is -1.
Addresses sissue #417 

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->