### PR TITLE
fix: keep connection properties in connection URL when creating new hosts after failover

### DIFF
--- a/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
+++ b/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
@@ -1103,3 +1103,5 @@ ClusterAwareReaderFailoverHandler.3=[ClusterAwareReaderFailoverHandler] Trying t
 ClusterAwareReaderFailoverHandler.4=[ClusterAwareReaderFailoverHandler] Connected to reader [{0,number,#}] ''{1}''
 ClusterAwareReaderFailoverHandler.5=[ClusterAwareReaderFailoverHandler] Failed to connect to reader [{0,number,#}] ''{1}''
 ClusterAwareReaderFailoverHandler.6=[ClusterAwareReaderFailoverHandler] {0} was called with an invalid (null or empty) topology
+
+ConnectionUtils.1=[ConnectionUtils] Unable to encode property value.

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
@@ -465,9 +465,9 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
    */
   protected ConnectionImpl createConnectionForHost(HostInfo baseHostInfo)
       throws SQLException {
-    HostInfo hostInfoWithInitialProps = ConnectionUtils.copyWithAdditionalProps(
+    HostInfo hostInfoWithInitialProps = ConnectionUtils.createHostWithProperties(
         baseHostInfo,
-        this.currentConnectionProvider.getCurrentHostInfo());
+        this.initialConnectionProps);
     return this.connectionProvider.connect(hostInfoWithInitialProps);
   }
 

--- a/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPluginTest.java
+++ b/src/test/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPluginTest.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.refEq;
@@ -61,6 +62,7 @@ import com.mysql.cj.jdbc.ha.plugins.ICurrentConnectionProvider;
 import com.mysql.cj.log.Log;
 import java.util.Objects;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -79,12 +81,19 @@ class FailoverConnectionPluginTest {
   private static final String URL = "somehost:1234";
   private static final int PORT = 1234;
   private static final String DATABASE = "test";
-  private final HostInfo writerHost =
-      ClusterAwareTestUtils.createBasicHostInfo("writer");
-  private final HostInfo readerHost =
-      ClusterAwareTestUtils.createBasicHostInfo("reader");
   private final List<HostInfo> mockTopology =
       new ArrayList<>(Arrays.asList(writerHost, readerHost));
+  static HostInfo writerHost;
+  static HostInfo readerHost;
+  static {
+    try {
+      writerHost = ClusterAwareTestUtils.createBasicHostInfo("writer");
+      readerHost = ClusterAwareTestUtils.createBasicHostInfo("reader");
+    } catch (SQLException e) {
+      fail();
+    }
+  }
+
   @Mock private ConnectionImpl mockConnection;
   @Mock private IConnectionProvider mockConnectionProvider;
   @Mock private ICurrentConnectionProvider mockCurrentConnectionProvider;

--- a/src/test/java/com/mysql/cj/util/ConnectionUtilsTest.java
+++ b/src/test/java/com/mysql/cj/util/ConnectionUtilsTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2.0
+ * (GPLv2), as published by the Free Software Foundation, with the
+ * following additional permissions:
+ *
+ * This program is distributed with certain software that is licensed
+ * under separate terms, as designated in a particular file or component
+ * or in the license documentation. Without limiting your rights under
+ * the GPLv2, the authors of this program hereby grant you an additional
+ * permission to link the program and your derivative works with the
+ * separately licensed software that they have included with the program.
+ *
+ * Without limiting the foregoing grant of rights under the GPLv2 and
+ * additional permission as to separately licensed software, this
+ * program is also subject to the Universal FOSS Exception, version 1.0,
+ * a copy of which can be found along with its FAQ at
+ * http://oss.oracle.com/licenses/universal-foss-exception.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License, version 2.0, for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see
+ * http://www.gnu.org/licenses/gpl-2.0.html.
+ */
+
+package com.mysql.cj.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.mysql.cj.conf.PropertyKey;
+import com.mysql.cj.jdbc.ha.ConnectionUtils;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ConnectionUtilsTest {
+
+  @ParameterizedTest
+  @MethodSource("urlArguments")
+  void test_buildUrl(
+      final String endpoint,
+      final String server,
+      final String port,
+      final String db,
+      final String expected,
+      final Properties props) throws SQLException {
+    final Properties properties = new Properties();
+    properties.putAll(props);
+    properties.setProperty(server, server);
+    properties.setProperty(PropertyKey.DBNAME.getKeyName(), db);
+
+    final String actual = ConnectionUtils.getUrlFromEndpoint(
+        endpoint,
+        Integer.parseInt(port),
+        properties);
+    assertEquals(expected, actual);
+  }
+
+  static Stream<Arguments> urlArguments() {
+    final Properties properties = new Properties();
+    properties.setProperty("bar", "baz");
+    return Stream.of(
+        Arguments.of(
+            "fooUrl",
+            "",
+            "3306",
+            "database",
+            "jdbc:mysql:aws://fooUrl:3306/database?bar=baz",
+            properties),
+        Arguments.of(
+            "fooUrl",
+            " ",
+            "-1",
+            "database",
+            "jdbc:mysql:aws://fooUrl/database?bar=baz",
+            properties),
+        Arguments.of(
+            "fooUrl",
+            "server",
+            "3306",
+            "database",
+            "jdbc:mysql:aws://fooUrl:3306/database?bar=baz&server=server",
+            properties),
+        Arguments.of(
+            "fooUrl",
+            "server",
+            "3306",
+            "",
+            "jdbc:mysql:aws://fooUrl:3306?bar=baz&server=server",
+            properties)
+    );
+  }
+}


### PR DESCRIPTION
### Summary

Keep connection properties in connection URL when creating new hosts after failover

### Description

When new hostInfo objects were made post-failover, the ConnectionUrl object was missing connection properties, leading to inaccurate metadata.

Adresses https://github.com/awslabs/aws-mysql-jdbc/issues/407#issuecomment-1589188945

### Additional Reviewers

<!-- Any additional reviewers -->