### PR TITLE
fix: ensure the failover plugin initial properties contain updated values from previous plugins

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
@@ -1038,6 +1038,8 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
   }
 
   private void createConnection(ConnectionUrl connectionUrl) throws SQLException {
+    // Update initial properties in case previous plugins have changed values
+    this.initialConnectionProps.putAll(connectionUrl.getOriginalProperties());
 
     if (this.enableFailoverSetting) {
       // Connection isn't created - try to use cached topology to create it


### PR DESCRIPTION
### Summary

Ensure the failover plugin initial properties contain updated values from previous plugins

### Description

After the changes in #410, the Failover plugin was missing any connection property changes that were made when `openInitialConnection` was called in plugins earlier in the plugin chain, such the the AWS Secrets Manager plugin. This PR updates the initial connection properties based on the ConnectionUrl provided by the previous plugin in the plugin chain.

### Additional Reviewers

<!-- Any additional reviewers -->