### PR TITLE
fix: avoid updating topology during a global transaction

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
@@ -210,25 +210,21 @@ public class AuroraTopologyService implements ITopologyService {
     long startTimeMs = System.currentTimeMillis();
 
     ClusterTopologyInfo topologyInfo = null;
-    if (!conn.isInGlobalTx() && !conn.isInPreparedTx()) {
-      synchronized (this) {
-        if (!conn.isInGlobalTx() && !conn.isInPreparedTx()) {
-          try (Statement stmt = conn.createStatement()) {
-            try (ResultSet resultSet = stmt.executeQuery(RETRIEVE_TOPOLOGY_SQL)) {
-              topologyInfo = processQueryResults(resultSet);
-            }
-          } catch (SQLSyntaxErrorException e) {
-            // We may get SQLSyntaxErrorException like the following from MySQL databases:
-            // "Unknown table 'REPLICA_HOST_STATUS' in information_schema"
-            // Ignore this kind of exceptions.
-          } finally {
-            if (gatherPerfMetrics(conn.getPropertySet())) {
-              long currentTimeMs = System.currentTimeMillis();
-              this.metricsContainer.registerTopologyQueryExecutionTime(currentTimeMs - startTimeMs);
-            }
+      if (!conn.isInGlobalTx() && !conn.isInPreparedTx()) {
+        try (Statement stmt = conn.createStatement()) {
+          try (ResultSet resultSet = stmt.executeQuery(RETRIEVE_TOPOLOGY_SQL)) {
+            topologyInfo = processQueryResults(resultSet);
+          }
+        } catch (SQLSyntaxErrorException e) {
+          // We may get SQLSyntaxErrorException like the following from MySQL databases:
+          // "Unknown table 'REPLICA_HOST_STATUS' in information_schema"
+          // Ignore this kind of exceptions.
+        } finally {
+          if (gatherPerfMetrics(conn.getPropertySet())) {
+            long currentTimeMs = System.currentTimeMillis();
+            this.metricsContainer.registerTopologyQueryExecutionTime(currentTimeMs - startTimeMs);
           }
         }
-      }
     }
 
     return topologyInfo != null

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/AuroraTopologyService.java
@@ -210,21 +210,21 @@ public class AuroraTopologyService implements ITopologyService {
     long startTimeMs = System.currentTimeMillis();
 
     ClusterTopologyInfo topologyInfo = null;
-      if (!conn.isInGlobalTx() && !conn.isInPreparedTx()) {
-        try (Statement stmt = conn.createStatement()) {
-          try (ResultSet resultSet = stmt.executeQuery(RETRIEVE_TOPOLOGY_SQL)) {
-            topologyInfo = processQueryResults(resultSet);
-          }
-        } catch (SQLSyntaxErrorException e) {
-          // We may get SQLSyntaxErrorException like the following from MySQL databases:
-          // "Unknown table 'REPLICA_HOST_STATUS' in information_schema"
-          // Ignore this kind of exceptions.
-        } finally {
-          if (gatherPerfMetrics(conn.getPropertySet())) {
-            long currentTimeMs = System.currentTimeMillis();
-            this.metricsContainer.registerTopologyQueryExecutionTime(currentTimeMs - startTimeMs);
-          }
+    if (!conn.isInGlobalTx() && !conn.isInPreparedTx()) {
+      try (Statement stmt = conn.createStatement()) {
+        try (ResultSet resultSet = stmt.executeQuery(RETRIEVE_TOPOLOGY_SQL)) {
+          topologyInfo = processQueryResults(resultSet);
         }
+      } catch (SQLSyntaxErrorException e) {
+        // We may get SQLSyntaxErrorException like the following from MySQL databases:
+        // "Unknown table 'REPLICA_HOST_STATUS' in information_schema"
+        // Ignore this kind of exceptions.
+      } finally {
+        if (gatherPerfMetrics(conn.getPropertySet())) {
+          long currentTimeMs = System.currentTimeMillis();
+          this.metricsContainer.registerTopologyQueryExecutionTime(currentTimeMs - startTimeMs);
+        }
+      }
     }
 
     return topologyInfo != null

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/failover/FailoverConnectionPlugin.java
@@ -728,6 +728,7 @@ public class FailoverConnectionPlugin implements IConnectionPlugin {
             || !this.isClusterTopologyAvailable
             || connection == null
             || connection.isClosed()
+            || connection.isInGlobalTx()
             || connection.isInPreparedTx()) {
       return;
     }


### PR DESCRIPTION
### Summary

Check the global transaction state before querying the topology

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->