### PR TITLE
fix: redundant reset statement called due to incorrect condition

### DIFF
--- a/src/main/core-impl/java/com/mysql/cj/ServerPreparedQuery.java
+++ b/src/main/core-impl/java/com/mysql/cj/ServerPreparedQuery.java
@@ -556,7 +556,7 @@ public class ServerPreparedQuery extends ClientPreparedQuery {
 
         if (this.queryBindings != null) {
             hadLongData = this.queryBindings.clearBindValues();
-            this.queryBindings.setLongParameterSwitchDetected(clearServerParameters && hadLongData ? false : true);
+            this.queryBindings.setLongParameterSwitchDetected(clearServerParameters && hadLongData);
         }
 
         if (clearServerParameters && hadLongData) {


### PR DESCRIPTION
### Summary

Addresses #422 
Port over fix from https://github.com/mysql/mysql-connector-j/pull/97

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->