### PR TITLE
fix: add check to prevent updateCounts being set to an invalid number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,23 +3,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/#semantic-versioning-200).
 
+## [?]
+### Fixed
+* Incorrect BatchUpdateException.getUpdateCounts() on failed batch statement execution ([Issue #450](https://github.com/awslabs/aws-mysql-jdbc/issues/450)).
+
 ## [1.1.9] - 2023-07-31
 ### Added
-- Documentation:
-  - An example of how to enable logging ([PR #431](https://github.com/awslabs/aws-mysql-jdbc/pull/431)).
-  - Release policy ([PR #434](https://github.com/awslabs/aws-mysql-jdbc/pull/434)).
-- The `keepSessionStateOnFailover` failover property to allow retaining the connection session state after failover without manually reconfiguring a connection ([Issue #425](https://github.com/awslabs/aws-mysql-jdbc/issues/425)).
+* Documentation:
+  * An example of how to enable logging ([PR #431](https://github.com/awslabs/aws-mysql-jdbc/pull/431)).
+  * Release policy ([PR #434](https://github.com/awslabs/aws-mysql-jdbc/pull/434)).
+* The `keepSessionStateOnFailover` failover property to allow retaining the connection session state after failover without manually reconfiguring a connection ([Issue #425](https://github.com/awslabs/aws-mysql-jdbc/issues/425)).
 
 ### Fixed
-- Avoid updating topology during global transactions which caused JTA transactions to fail ([Issue #292](https://github.com/awslabs/aws-mysql-jdbc/issues/292)).
-- Keep `currentHostIndex` and hosts list in sync and pick a new connection when host role changes ([Issue #303](https://github.com/awslabs/aws-mysql-jdbc/issues/303)).
-- Redundant reset statement called due to incorrect condition ([Issue #422](https://github.com/awslabs/aws-mysql-jdbc/pull/435)).
+* Avoid updating topology during global transactions which caused JTA transactions to fail ([Issue #292](https://github.com/awslabs/aws-mysql-jdbc/issues/292)).
+* Keep `currentHostIndex` and hosts list in sync and pick a new connection when host role changes ([Issue #303](https://github.com/awslabs/aws-mysql-jdbc/issues/303)).
+* Redundant reset statement called due to incorrect condition ([Issue #422](https://github.com/awslabs/aws-mysql-jdbc/pull/435)).
 
 ## [1.1.8] - 2023-06-28
 ### Fixed
-- The topology service cache no longer stores connection specific properties so connections to the same cluster will not connect with the wrong properties ([Issue #407](https://github.com/awslabs/aws-mysql-jdbc/issues/407)).
-- Fixed value `convertToNull` being rejected for property `zeroDateTimeBehavior` because of capitalization ([Issue #411](https://github.com/awslabs/aws-mysql-jdbc/pull/413)).
-- Handle case in the `FailoverConnectionPlugin` where the `currentHostIndex` is equal to `NO_CONNECTION_INDEX` ([Issue #417](https://github.com/awslabs/aws-mysql-jdbc/issues/417)).
+* The topology service cache no longer stores connection specific properties so connections to the same cluster will not connect with the wrong properties ([Issue #407](https://github.com/awslabs/aws-mysql-jdbc/issues/407)).
+* Fixed value `convertToNull` being rejected for property `zeroDateTimeBehavior` because of capitalization ([Issue #411](https://github.com/awslabs/aws-mysql-jdbc/pull/413)).
+* Handle case in the `FailoverConnectionPlugin` where the `currentHostIndex` is equal to `NO_CONNECTION_INDEX` ([Issue #417](https://github.com/awslabs/aws-mysql-jdbc/issues/417)).
 
 ## [1.1.7] - 2023-05-11
 ### Changed

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/StatementImpl.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/StatementImpl.java
@@ -25,6 +25,8 @@
  * You should have received a copy of the GNU General Public License along with
  * this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+ *
+ * Modifications Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  */
 
 package com.mysql.cj.jdbc;
@@ -1053,7 +1055,9 @@ public class StatementImpl implements JdbcStatement {
 
     protected int processMultiCountsAndKeys(StatementImpl batchedStatement, int updateCountCounter, long[] updateCounts) throws SQLException {
         synchronized (checkClosed().getConnectionMutex()) {
-            updateCounts[updateCountCounter++] = batchedStatement.getLargeUpdateCount();
+            if (batchedStatement.getLargeUpdateCount() != -1) {
+                updateCounts[updateCountCounter++] = batchedStatement.getLargeUpdateCount();
+            }
 
             boolean doGenKeys = this.batchedGeneratedKeys != null;
 


### PR DESCRIPTION
### Summary

fix: add check to prevent updateCounts being set to an invalid number

### Description

When an error occurs on executing a batch statement while `allowMultiQueries` is set to true, the updateCounts is incorrectly set to -1 when it should be left as -3 (`Statement.EXECUTE_FAILED`). This PR adds a check to ensure this does not happen.

Addresses #450.

### Additional Reviewers

<!-- Any additional reviewers -->