### PR TITLE
fix: batch execute with comments results in error

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/StatementImpl.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/StatementImpl.java
@@ -364,7 +364,7 @@ public class StatementImpl implements JdbcStatement {
      */
     protected boolean isNonResultSetProducingQuery(String sql) {
         QueryReturnType queryReturnType = QueryInfo.getQueryReturnType(sql, this.session.getServerSession().isNoBackslashEscapesSet());
-        return queryReturnType == QueryReturnType.DOES_NOT_PRODUCE_RESULT_SET || queryReturnType == QueryReturnType.MAY_PRODUCE_RESULT_SET;
+        return queryReturnType == QueryReturnType.DOES_NOT_PRODUCE_RESULT_SET || queryReturnType == QueryReturnType.MAY_PRODUCE_RESULT_SET || queryReturnType == QueryReturnType.NONE;
     }
 
     /**


### PR DESCRIPTION
### Summary

Batch execute with comments results in error

### Description

Batch execute with comments resulted in errors about being unable to issue statements that produce result sets. The `isNonResultSetProducingQuery` method was missing the `None` query return type.

Addresses #464 

### Additional Reviewers

<!-- Any additional reviewers -->