### PR TITLE
fix: incorrect generated keys after batch and individual statement executions

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/StatementImpl.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/StatementImpl.java
@@ -1323,6 +1323,7 @@ public class StatementImpl implements JdbcStatement {
 
                 if (!isBatch) {
                     this.query.getStatementExecuting().set(false);
+                    this.batchedGeneratedKeys = null;
                 }
             }
 


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

### Description

When batch statements are executed, followed by individual statements, the generated keys will be for the batch statements.  This PR allows the generated keys for the statement to be for the latest statement execution.

Addresses #484 

### Additional Reviewers

<!-- Any additional reviewers -->