### PR TITLE
update mysql docker container image to 8.0.36

### DIFF
--- a/src/test/java/testsuite/integration/utility/ContainerHelper.java
+++ b/src/test/java/testsuite/integration/utility/ContainerHelper.java
@@ -71,7 +71,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ContainerHelper {
   private static final String TEST_CONTAINER_IMAGE_NAME = "openjdk:8-jdk-alpine";
-  private static final String MYSQL_CONTAINER_IMAGE_NAME = "mysql:8.0.28";
+  private static final String MYSQL_CONTAINER_IMAGE_NAME = "mysql:8.0.36";
   private static final DockerImageName TOXIPROXY_IMAGE = DockerImageName.parse("shopify/toxiproxy:2.1.4");
 
   private static final String RETRIEVE_TOPOLOGY_SQL =


### PR DESCRIPTION
### Summary

update mysql docker container image to 8.0.36

### Description

update mysql docker container image to 8.0.36
### Additional Reviewers

<!-- Any additional reviewers -->