### PR TITLE
fix: IAM auth in CN RDS (#579)

### DIFF
--- a/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
+++ b/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
@@ -69,7 +69,7 @@ AuthenticationProvider.BadDisabledAuthenticationPlugin=Can''t disable the defaul
 AuthenticationProvider.AuthenticationPluginRequiresSSL=SSL connection required for plugin "{0}". Check if ''sslMode'' is enabled.
 AuthenticationProvider.UnexpectedAuthenticationApproval=Unexpected authentication approval. Authentication plugin "{0}" did not report "done" state but server has approved the connection.
 
-AuthenticationAwsIamPlugin.UnsupportedHostname=Unsupported AWS hostname ''{0}''. Amazon domain name in format *.AWS-Region.rds.amazonaws.com is expected
+AuthenticationAwsIamPlugin.UnsupportedHostname=Unsupported AWS hostname ''{0}''. Amazon domain name in format *.AWS-Region.rds.amazonaws.com or *.rds.AWS-Region.amazonaws.com.cn is expected
 AuthenticationAwsIamPlugin.UnsupportedRegion=Unsupported AWS region ''{0}''. For supported regions, please read https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html
 AuthenticationAwsIamPlugin.MissingSDK=Unable to connect using AWS IAM authentication due to missing AWS Java SDK For Amazon RDS. Add dependency to classpath.
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/util/RdsUtils.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/util/RdsUtils.java
@@ -77,7 +77,7 @@ public class RdsUtils {
   // Instance Endpoint: <instance-name>.<xyz>.rds.<aws-region>.amazonaws.com.cn
   // Example: test-postgres-instance-1.123456789012.rds.cn-northwest-1.amazonaws.com.cn
 
-  private static final Pattern AURORA_DNS_PATTERN =
+  public static final Pattern AURORA_DNS_PATTERN =
       Pattern.compile(
           "(?<instance>.+)\\."
               + "(?<dns>proxy-|cluster-|cluster-ro-|cluster-custom-)?"
@@ -104,7 +104,7 @@ public class RdsUtils {
               + "(?<domain>[a-zA-Z0-9]+\\.(?<region>[a-zA-Z0-9\\-]+)\\.rds\\.amazonaws\\.com(\\.cn)?)",
           Pattern.CASE_INSENSITIVE);
 
-  private static final Pattern AURORA_CHINA_DNS_PATTERN =
+  public static final Pattern AURORA_CHINA_DNS_PATTERN =
       Pattern.compile(
           "(?<instance>.+)\\."
               + "(?<dns>proxy-|cluster-|cluster-ro-|cluster-custom-)?"

--- a/src/test/java/testsuite/simple/AwsIamAuthenticationHelperTest.java
+++ b/src/test/java/testsuite/simple/AwsIamAuthenticationHelperTest.java
@@ -51,6 +51,18 @@ public class AwsIamAuthenticationHelperTest {
             PORT,
             StandardLogger.class.getName()
         ));
+
+        Assertions.assertNotNull(new AwsIamAuthenticationTokenHelper(
+            "MyDBInstanceName.SomeServerName.us-east-1.rds.amazonaws.com.cn",
+            PORT,
+            StandardLogger.class.getName()
+        ));
+
+        Assertions.assertNotNull(new AwsIamAuthenticationTokenHelper(
+            "test-postgres.cluster-123456789012.rds.cn-northwest-1.amazonaws.com.cn",
+            PORT,
+            StandardLogger.class.getName()
+        ));
     }
 
 


### PR DESCRIPTION
### Summary

fix: IAM auth in CN RDS (#579)

### Description

Previously `AwsIamAuthenticationTokenHelper#getRegion` aurora DNS pattern did not support CN regions. Added an aurora DNS pattern for CN region specifically. 

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the GPLv2 license.
