### PR TITLE
fix: EFM v2 Monitor to use ConcurrentHashMap instead of HashMap to fi…

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/efm2/Monitor.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/plugins/efm2/Monitor.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -65,7 +66,7 @@ public class Monitor implements IMonitor {
   protected static final Executor ABORT_EXECUTOR = Executors.newSingleThreadExecutor();
 
   private final Queue<WeakReference<MonitorConnectionContext>> activeContexts = new ConcurrentLinkedQueue<>();
-  private final HashMap<Long, Queue<WeakReference<MonitorConnectionContext>>> newContexts = new HashMap<>();
+  private final Map<Long, Queue<WeakReference<MonitorConnectionContext>>> newContexts = new ConcurrentHashMap<>();
 
   private final AtomicBoolean stopped = new AtomicBoolean(false);
   private Connection monitoringConn = null;


### PR DESCRIPTION

### Summary

fix: EFM v2 Monitor to use ConcurrentHashMap instead of HashMap to fix ConcurrentModificationException

### Description

fix: EFM v2 Monitor to use ConcurrentHashMap instead of HashMap to fix ConcurrentModificationException

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the GPLv2 license.
