### PR TITLE
Bump com.google.protobuf:protobuf-java from 3.21.9 to 3.25.5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -278,16 +278,19 @@ dependencies {
     testImplementation("org.apache.poi:poi-ooxml:5.2.3")
     testImplementation("com.zaxxer:HikariCP:4.0.3")
     testImplementation("software.amazon.awssdk:secretsmanager:2.23.12")
+    testImplementation("com.fasterxml.jackson.core:jackson-databind:2.17.1")
 
     implementation("software.amazon.awssdk:rds:2.25.1")
-    implementation("com.google.protobuf:protobuf-java:3.21.9")
+    implementation("com.google.protobuf:protobuf-java:3.25.5")
     implementation("com.mchange:c3p0:0.10.1")
     implementation("org.javassist:javassist:3.28.0-GA")
     implementation("org.slf4j:slf4j-api:2.0.1")
     implementation("com.oracle.oci.sdk:oci-java-sdk-common:3.42.0")
+    implementation("org.checkerframework:checker-qual:3.47.0")
     compileOnly("software.amazon.awssdk:secretsmanager:2.23.12")
 
     compileOnly("org.ajoberstar.grgit:grgit-gradle:4.1.1")
+    compileOnly("com.fasterxml.jackson.core:jackson-databind:2.17.1")
 }
 
 sourceSets {

--- a/src/build/misc/pom.xml
+++ b/src/build/misc/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.21.9</version>
+      <version>3.25.5</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Summary

Bump com.google.protobuf:protobuf-java from 3.21.9 to 3.25.5

### Additional Reviewers

@karenc-bq 

### By submitting this pull request, I confirm that my contribution is made under the terms of the GPLv2 license.
