### PR TITLE
fix: query cache size version cutoff

### DIFF
--- a/src/main/core-impl/java/com/mysql/cj/NativeSession.java
+++ b/src/main/core-impl/java/com/mysql/cj/NativeSession.java
@@ -430,7 +430,7 @@ public class NativeSession extends CoreSession implements Serializable {
                 queryBuf.append(", @@max_allowed_packet AS max_allowed_packet");
                 queryBuf.append(", @@net_write_timeout AS net_write_timeout");
                 queryBuf.append(", @@performance_schema AS performance_schema");
-                if (!versionMeetsMinimum(8, 0, 3)) {
+                if (!versionMeetsMinimum(8, 0, 0)) {
                     queryBuf.append(", @@query_cache_size AS query_cache_size");
                     queryBuf.append(", @@query_cache_type AS query_cache_type");
                 }


### PR DESCRIPTION
> The query cache is deprecated as of MySQL 5.7.20, and is removed in MySQL 8.0
> https://dev.mysql.com/doc/refman/5.7/en/query-cache-configuration.html

This pull request lowers the minimum version cutoff for `query_cache_size` and `query_cache_type` from `8.0.3` to `8.0.0`.